### PR TITLE
Generate final SMART goal and log finalization

### DIFF
--- a/src/goals/services.py
+++ b/src/goals/services.py
@@ -72,21 +72,29 @@ class AiCoach:
 
     def finalize(self, goal) -> str:
         score = goal.smart_score or {}
-        missing = [c for c in ["specific", "measurable", "achievable", "relevant", "time_bound"] if not score.get(c)]
+        missing = [
+            c
+            for c in ["specific", "measurable", "achievable", "relevant", "time_bound"]
+            if not score.get(c)
+        ]
         conversation = self._conversation(goal)
         mapping = {
-            "specific": "konkreter", "measurable": "messbar", "achievable": "realistischer",
-            "relevant": "relevanter zum Thema", "time_bound": "zeitlich klarer",
+            "specific": "konkreter",
+            "measurable": "messbarer",
+            "achievable": "realistischer",
+            "relevant": "relevanter zum Thema",
+            "time_bound": "zeitlich klarer",
         }
         if missing:
             miss_text = ", ".join(mapping[c] for c in missing)
             prompt = (
                 f"{SMART_PROMPT}\n{conversation}\n"
-                f"Schlage eine kurze Verbesserung vor, damit das Ziel {miss_text} wird."
+                "Formuliere daraus ein finales SMART-Ziel in weniger als 25 Wörtern. "
+                f"Es soll {miss_text} sein."
             )
         else:
             prompt = (
                 f"{SMART_PROMPT}\n{conversation}\n"
-                "Bestätige knapp, dass dieses Ziel SMART ist, und frage nach der Bestätigung zur Finalisierung."
+                "Formuliere daraus ein finales SMART-Ziel in weniger als 25 Wörtern."
             )
         return self.ask(prompt)


### PR DESCRIPTION
## Summary
- Add finalize prompt to produce concise SMART goal (<25 words) based on conversation.
- Finalize endpoint now uses AI coach to generate final goal, saves `final_text`, stamps `finalized_at`, recalculates SMART score and logs final assistant interaction.

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689cb462dbbc83248074c9e348386095