### PR TITLE
Enhance SMART goal evaluation heuristics

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,37 @@
+import json
+from goals.services import evaluate_smart
+
+
+class DummyClient:
+    class Responses:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def create(self, *args, **kwargs):
+            class Resp:
+                def __init__(self, payload):
+                    self.output = [
+                        type('obj', (), {
+                            'content': [type('obj', (), {'text': json.dumps(payload)})]
+                        })
+                    ]
+            return Resp(self.payload)
+
+    def __init__(self, payload):
+        self.responses = self.Responses(payload)
+
+
+def test_evaluate_smart_llm_parsing():
+    payload = {
+        "specific": True,
+        "measurable": False,
+        "achievable": True,
+        "relevant": True,
+        "time_bound": False,
+        "question": "Wie kannst du dein Ziel messbar machen?",
+    }
+    client = DummyClient(payload)
+    result = evaluate_smart("Ich möchte besser rechnen", "Mathe", client=client)
+    assert result["score"] == 3
+    assert result["question"] == "Wie kannst du dein Ziel messbar machen?"
+    assert result["measurable"] is False


### PR DESCRIPTION
## Summary
- route SMART goal analysis through OpenAI to determine missing criteria and follow-up question
- simplify coaching flow to rely on LLM output and finalize goals with lesson topic context
- add test harness mocking LLM responses for SMART scoring

## Testing
- `PYTHONPATH=src DJANGO_SETTINGS_MODULE=config.settings pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cb5d544b48324b714714ce13dd243