### PR TITLE
Add goal and reflection templates

### DIFF
--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -45,6 +45,30 @@ def dashboard(request):
     return render(request, "dashboard.html", {"user": request.user, "user_session_id": user_session.id})
 
 
+@login_required
+def goal_vg_page(request):
+    today = timezone.now().date()
+    lesson, _ = LessonSession.objects.get_or_create(date=today)
+    user_session, _ = UserSession.objects.get_or_create(user=request.user, lesson_session=lesson)
+    return render(request, "goal_vg.html", {"user_session_id": user_session.id})
+
+
+@login_required
+def goal_kg_page(request):
+    today = timezone.now().date()
+    lesson, _ = LessonSession.objects.get_or_create(date=today)
+    user_session, _ = UserSession.objects.get_or_create(user=request.user, lesson_session=lesson)
+    return render(request, "goal_kg.html", {"user_session_id": user_session.id})
+
+
+@login_required
+def reflection_page(request):
+    today = timezone.now().date()
+    lesson, _ = LessonSession.objects.get_or_create(date=today)
+    user_session, _ = UserSession.objects.get_or_create(user=request.user, lesson_session=lesson)
+    return render(request, "reflection.html", {"user_session_id": user_session.id})
+
+
 def login_page(request):
     if request.method == "POST":
         serializer = LoginSerializer(data=request.POST)

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -15,12 +15,21 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from accounts.views import login_page, dashboard
+from accounts.views import (
+    login_page,
+    dashboard,
+    goal_vg_page,
+    goal_kg_page,
+    reflection_page,
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", login_page, name="login"),
     path("dashboard/", dashboard, name="dashboard"),
+    path("goal/vg/", goal_vg_page, name="goal_vg"),
+    path("goal/kg/", goal_kg_page, name="goal_kg"),
+    path("reflection/", reflection_page, name="reflection"),
     path("api/", include("accounts.urls")),
     path("api/", include("lessons.urls")),
     path("api/", include("goals.urls")),

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+    <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <title>{% block title %}SRL Platform{% endblock %}</title>
 </head>
 <body class="p-4 max-w-xl mx-auto">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,19 +2,12 @@
 {% block title %}Dashboard{% endblock %}
 {% block content %}
 <h1 class="text-xl mb-4">Hallo {{ user.pseudonym }} ({{ user.gruppe }})</h1>
-<div id="goal-section">
-{% if user.gruppe == 'KG' %}
-<form hx-post="/api/goals/" hx-target="#goal-section" hx-swap="innerHTML" class="space-y-2">
-    <input type="hidden" name="user_session" value="{{ user_session_id }}" />
-    <textarea name="raw_text" class="w-full border p-2" placeholder="Was möchtest du heute erreichen?"></textarea>
-    <button class="bg-green-500 text-white px-4 py-2">Ziel speichern</button>
-</form>
-{% else %}
-<form hx-post="/api/vg/goals/" hx-target="#goal-section" hx-swap="innerHTML" class="space-y-2">
-    <input type="hidden" name="user_session" value="{{ user_session_id }}" />
-    <textarea name="raw_text" class="w-full border p-2" placeholder="Was möchtest du heute erreichen?"></textarea>
-    <button class="bg-green-500 text-white px-4 py-2">Dialog starten</button>
-</form>
-{% endif %}
+<div class="flex flex-col sm:flex-row gap-2" id="goal-section">
+    {% if user.gruppe == 'KG' %}
+    <a href="{% url 'goal_kg' %}" class="bg-green-500 text-white px-4 py-2 text-center w-full sm:w-auto">Ziel setzen</a>
+    {% else %}
+    <a href="{% url 'goal_vg' %}" class="bg-green-500 text-white px-4 py-2 text-center w-full sm:w-auto">Ziel setzen</a>
+    {% endif %}
+    <a href="{% url 'reflection' %}" class="bg-blue-500 text-white px-4 py-2 text-center w-full sm:w-auto">Reflexion</a>
 </div>
 {% endblock %}

--- a/templates/goal_kg.html
+++ b/templates/goal_kg.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Zielsetzung KG{% endblock %}
+{% block content %}
+<div x-data="goalKG()" class="space-y-4">
+    <form hx-post="/api/goals/" hx-swap="none" @htmx:afterRequest="updateSmart" class="space-y-2">
+        <input type="hidden" name="user_session" value="{{ user_session_id }}">
+        <textarea name="raw_text" class="w-full border p-2" placeholder="Was möchtest du erreichen?"></textarea>
+        <button class="bg-green-500 text-white px-4 py-2 w-full sm:w-auto">Ziel speichern</button>
+    </form>
+    <div class="flex flex-wrap gap-2 text-xs">
+        <template x-for="(val, key) in smart" :key="key">
+            <span class="px-2 py-1 rounded" :class="val ? 'bg-green-200' : 'bg-gray-200'" x-text="key"></span>
+        </template>
+    </div>
+</div>
+<script>
+function goalKG(){
+    return {
+        smart:{specific:false, measurable:false, achievable:false, relevant:false, time_bound:false},
+        updateSmart(e){
+            let data={};
+            try{ data = JSON.parse(e.detail.xhr.responseText);}catch(err){}
+            if(data.smart_score){ this.smart = data.smart_score; }
+        }
+    }
+}
+</script>
+{% endblock %}

--- a/templates/goal_vg.html
+++ b/templates/goal_vg.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+{% block title %}Zielsetzung VG{% endblock %}
+{% block content %}
+<div x-data="goalCoach()" class="space-y-4">
+    <div id="chat" class="space-y-2 border p-2 rounded h-64 overflow-y-auto"></div>
+    <form :hx-post="goalId ? '/api/vg/coach/next/' : '/api/vg/goals/'"
+          hx-swap="none"
+          @htmx:afterRequest="handleResponse"
+          class="flex flex-col sm:flex-row gap-2">
+        <input type="hidden" name="user_session" value="{{ user_session_id }}" x-show="!goalId">
+        <input type="hidden" name="goal_id" :value="goalId" x-show="goalId">
+        <textarea x-model="message" class="flex-1 border p-2" placeholder="Deine Nachricht..."></textarea>
+        <input type="hidden" name="raw_text" :value="message" x-show="!goalId">
+        <input type="hidden" name="user_reply" :value="message" x-show="goalId">
+        <button class="bg-blue-500 text-white px-4 py-2 sm:self-start">Senden</button>
+    </form>
+    <div class="flex flex-wrap gap-2 text-xs">
+        <template x-for="(val, key) in smart" :key="key">
+            <span class="px-2 py-1 rounded" :class="val ? 'bg-green-200' : 'bg-gray-200'" x-text="key"></span>
+        </template>
+    </div>
+</div>
+<script>
+function goalCoach(){
+    return {
+        message:'',
+        goalId:null,
+        smart:{specific:false, measurable:false, achievable:false, relevant:false, time_bound:false},
+        handleResponse(e){
+            let data = {};
+            try { data = JSON.parse(e.detail.xhr.responseText); } catch(err){}
+            if(!this.goalId && data.id){ this.goalId = data.id; }
+            if(this.message){ this.addMessage('user', this.message); }
+            if(data.assistant_text){ this.addMessage('assistant', data.assistant_text); }
+            if(data.smart_status){ this.smart = data.smart_status; }
+            this.message='';
+        },
+        addMessage(role,text){
+            const chat = document.getElementById('chat');
+            const div = document.createElement('div');
+            div.className = role==='assistant'? 'text-blue-700' : 'text-gray-700 text-right';
+            div.textContent = text;
+            chat.appendChild(div);
+            chat.scrollTop = chat.scrollHeight;
+        }
+    }
+}
+</script>
+{% endblock %}

--- a/templates/reflection.html
+++ b/templates/reflection.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}Reflexion{% endblock %}
+{% block content %}
+<div x-data="{submitted:false}">
+    <form x-show="!submitted" hx-post="/api/reflections/" hx-swap="none" @htmx:afterRequest="submitted=true" class="space-y-2">
+        <input type="hidden" name="user_session" value="{{ user_session_id }}">
+        <textarea name="result" class="w-full border p-2" placeholder="Was hast du erreicht?"></textarea>
+        <textarea name="obstacles" class="w-full border p-2" placeholder="Welche Hindernisse gab es?"></textarea>
+        <textarea name="next_step" class="w-full border p-2" placeholder="Was ist dein nächster Schritt?"></textarea>
+        <button class="bg-blue-500 text-white px-4 py-2 w-full sm:w-auto">Reflexion speichern</button>
+    </form>
+    <div x-show="submitted" class="p-4 bg-green-100 rounded">Danke für deine Reflexion!</div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add goal_vg, goal_kg, and reflection templates using htmx and Alpine.js
- Link new views from dashboard with mobile-friendly buttons
- Expose goal and reflection pages via new Django views and URL routes

## Testing
- `python -m pytest` (fails: Requested setting REST_FRAMEWORK, but settings are not configured)

------
https://chatgpt.com/codex/tasks/task_e_689cbede62708324a15b8a0ea22af809