### PR TITLE
Add reflection form with AI suggestions and dashboard link

### DIFF
--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -12,6 +12,7 @@ from rest_framework.permissions import AllowAny
 from .models import User
 from .serializers import LoginSerializer, UserSerializer
 from lessons.models import LessonSession, UserSession
+from goals.models import Goal
 
 
 class LoginView(APIView):
@@ -71,7 +72,12 @@ def reflection_page(request):
     today = timezone.now().date()
     lesson, _ = LessonSession.objects.get_or_create(date=today)
     user_session, _ = UserSession.objects.get_or_create(user=request.user, lesson_session=lesson)
-    return render(request, "reflection.html", {"user_session_id": user_session.id})
+    goal = Goal.objects.filter(user_session=user_session).first()
+    context = {
+        "user_session_id": user_session.id,
+        "goal_id": getattr(goal, "id", ""),
+    }
+    return render(request, "reflection.html", context)
 
 
 def login_page(request):

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -8,6 +8,6 @@
     {% else %}
     <a href="{% url 'goal_kg' %}" class="bg-green-500 text-white px-4 py-2 text-center w-full sm:w-auto">Ziel setzen</a>
     {% endif %}
-    <a href="{% url 'reflection' %}" class="bg-blue-500 text-white px-4 py-2 text-center w-full sm:w-auto">Reflexion</a>
+    <a href="{% url 'reflection' %}" class="bg-blue-500 text-white px-4 py-2 text-center w-full sm:w-auto">Reflexion starten</a>
 </div>
 {% endblock %}

--- a/templates/reflection.html
+++ b/templates/reflection.html
@@ -1,14 +1,54 @@
 {% extends 'base.html' %}
 {% block title %}Reflexion{% endblock %}
 {% block content %}
-<div x-data="{submitted:false}">
-    <form x-show="!submitted" hx-post="/api/reflections/" hx-swap="none" @htmx:afterRequest="submitted=true" class="space-y-2">
+<div x-data="reflectionForm()" class="space-y-2">
+    <form x-show="!submitted"
+          hx-post="/api/reflections/"
+          hx-swap="none"
+          @htmx:afterRequest="submitted=true; setTimeout(()=>window.location.href='{% url 'dashboard' %}',1500)"
+          class="space-y-2">
         <input type="hidden" name="user_session" value="{{ user_session_id }}">
-        <textarea name="result" class="w-full border p-2" placeholder="Was hast du erreicht?"></textarea>
+        <input type="hidden" name="goal" value="{{ goal_id }}">
+        <div class="space-y-1">
+            <p>Hast du dein Ziel erreicht?</p>
+            <label class="block"><input type="radio" name="result" value="yes"> Ja</label>
+            <label class="block"><input type="radio" name="result" value="partial"> Teilweise</label>
+            <label class="block"><input type="radio" name="result" value="no"> Nein</label>
+        </div>
         <textarea name="obstacles" class="w-full border p-2" placeholder="Welche Hindernisse gab es?"></textarea>
         <textarea name="next_step" class="w-full border p-2" placeholder="Was ist dein nächster Schritt?"></textarea>
+        <button type="button"
+                class="bg-gray-500 text-white px-4 py-2 w-full sm:w-auto"
+                hx-post="/api/vg/next-step/suggest/"
+                hx-include="closest form"
+                hx-swap="none"
+                @htmx:afterRequest="handleSuggestions">KI-Vorschläge anzeigen</button>
+        <div class="space-y-1" x-show="suggestions.length">
+            <template x-for="s in suggestions" :key="s">
+                <button type="button" class="border w-full text-left px-2 py-1"
+                        hx-post="/api/vg/next-step/suggest/"
+                        :hx-vals="{selected: s}"
+                        hx-include="closest form"
+                        hx-swap="none"
+                        @htmx:afterRequest="submitted=true; setTimeout(()=>window.location.href='{% url 'dashboard' %}',1500)"
+                        x-text="s"></button>
+            </template>
+        </div>
         <button class="bg-blue-500 text-white px-4 py-2 w-full sm:w-auto">Reflexion speichern</button>
     </form>
     <div x-show="submitted" class="p-4 bg-green-100 rounded">Danke für deine Reflexion!</div>
 </div>
+<script>
+function reflectionForm(){
+    return {
+        suggestions: [],
+        submitted: false,
+        handleSuggestions(e){
+            let data = {};
+            try { data = JSON.parse(e.detail.xhr.responseText); } catch(err){}
+            this.suggestions = data.suggestions || [];
+        }
+    }
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add "Reflexion starten" link on dashboard
- Implement reflection form with result radio buttons, obstacles, next-step fields and AI suggestions
- Supply goal id to reflection page for suggestion endpoint

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689cc565270483248bdf7c5b651e8d77