### PR TITLE
Show goal and reflection history on dashboard

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -53,7 +53,7 @@ ROOT_URLCONF = "config.urls"
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / "templates"],
+        'DIRS': [BASE_DIR / "templates", BASE_DIR.parent / "templates"],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -10,4 +10,49 @@
     {% endif %}
     <a href="{% url 'reflection' %}" class="bg-blue-500 text-white px-4 py-2 text-center w-full sm:w-auto">Reflexion starten</a>
 </div>
+{% if goals %}
+<h2 class="text-lg mt-6">Vergangene Ziele</h2>
+<div class="overflow-x-auto">
+<table class="min-w-full text-sm">
+    <thead>
+        <tr>
+            <th class="px-2 py-1 text-left">Ziel</th>
+            <th class="px-2 py-1 text-left">Datum</th>
+            <th class="px-2 py-1 text-left">SMART</th>
+            <th class="px-2 py-1 text-left">Reflexion</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for goal in goals %}
+        {% with reflection=goal.reflection_set.first %}
+        <tr class="border-t">
+            <td class="px-2 py-1">{{ goal.final_text|default:goal.raw_text }}</td>
+            <td class="px-2 py-1">{{ goal.user_session.lesson_session.date }}</td>
+            <td class="px-2 py-1">{% if goal.smart_score %}{{ goal.smart_score.overall }}{% else %}-{% endif %}</td>
+            <td class="px-2 py-1">{% if reflection %}{{ reflection.get_result_display }}{% else %}-{% endif %}</td>
+        </tr>
+        {% endwith %}
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+<canvas id="completionChart" class="mt-4"></canvas>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const rate = {{ completion_rate }};
+new Chart(document.getElementById('completionChart'), {
+    type: 'doughnut',
+    data: {
+        labels: ['Erfüllt','Offen'],
+        datasets: [{
+            data: [rate, 100 - rate],
+            backgroundColor: ['#22c55e','#e5e7eb']
+        }]
+    },
+    options: {
+        plugins: { legend: { position: 'bottom' } }
+    }
+});
+</script>
+{% endif %}
 {% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from accounts.models import User
+from lessons.models import LessonSession, UserSession, Classroom
+from goals.models import Goal
+from reflections.models import Reflection
+
+
+class DashboardHistoryTests(TestCase):
+    def setUp(self):
+        self.classroom = Classroom.objects.create(name="10A", use_ai=True)
+        self.user = User.objects.create_user(pseudonym="u1", gruppe=User.VG, classroom=self.classroom)
+        self.client.force_login(self.user)
+
+    def test_history_in_context(self):
+        past_lesson = LessonSession.objects.create(date="2024-01-01", classroom=self.classroom)
+        past_session = UserSession.objects.create(user=self.user, lesson_session=past_lesson)
+        goal = Goal.objects.create(user_session=past_session, raw_text="lorem", final_text="lorem", smart_score={"overall": 4})
+        Reflection.objects.create(user_session=past_session, goal=goal, result="yes", obstacles="", next_step="")
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("goals", response.context)
+        goals = response.context["goals"]
+        self.assertTrue(any(g.id == goal.id for g in goals))
+        self.assertEqual(goals[0].reflection_set.first().result, "yes")


### PR DESCRIPTION
## Summary
- Fetch recent goals and reflections in the dashboard view
- Display goal history with SMART score and reflection results, plus completion chart
- Ensure templates directory is loaded and add test for history context

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689dcf7872e48324b5ee9c56362286cf