### PR TITLE
Add overall goal model and integrate history into AI coach

### DIFF
--- a/src/goals/admin.py
+++ b/src/goals/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Goal, KIInteraction
+from .models import Goal, KIInteraction, OverallGoal
 
 class KIInteractionInline(admin.TabularInline):
     model = KIInteraction
@@ -9,3 +9,8 @@ class KIInteractionInline(admin.TabularInline):
 class GoalAdmin(admin.ModelAdmin):
     list_display = ("user_session", "raw_text", "final_text", "finalized_at")
     inlines = [KIInteractionInline]
+
+
+@admin.register(OverallGoal)
+class OverallGoalAdmin(admin.ModelAdmin):
+    list_display = ("user", "text", "created_at")

--- a/src/goals/migrations/0002_overallgoal.py
+++ b/src/goals/migrations/0002_overallgoal.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import uuid
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('goals', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='OverallGoal',
+            fields=[
+                ('id', models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)),
+                ('text', models.TextField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('user', models.ForeignKey(on_delete=models.CASCADE, related_name='overall_goals', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/src/goals/models.py
+++ b/src/goals/models.py
@@ -6,6 +6,18 @@ from django.conf import settings
 from lessons.models import UserSession
 
 
+class OverallGoal(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="overall_goals"
+    )
+    text = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):  # pragma: no cover - simple
+        return self.text[:20]
+
+
 class Goal(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user_session = models.ForeignKey(UserSession, on_delete=models.CASCADE)


### PR DESCRIPTION
## Summary
- add `OverallGoal` model tied to users and expose in admin
- include long-term and prior goals in AI coach prompts and API responses
- extend tests to cover prompt history handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd17df70c832480d2882b993308e7