### PR TITLE
Handle unknown users on login and add bulk student creation command

### DIFF
--- a/src/accounts/management/commands/create_students.py
+++ b/src/accounts/management/commands/create_students.py
@@ -1,0 +1,33 @@
+from django.core.management.base import BaseCommand, CommandError
+from accounts.models import User
+from lessons.models import Classroom
+
+class Command(BaseCommand):
+    help = "Create multiple student users. Provide pseudonyms and optional classroom code."
+
+    def add_arguments(self, parser):
+        parser.add_argument("pseudonyms", nargs="+", help="List of student pseudonyms to create")
+        parser.add_argument(
+            "--class-code",
+            dest="class_code",
+            help="Optional classroom code to assign",
+        )
+
+    def handle(self, *args, **options):
+        class_code = options.get("class_code")
+        classroom = None
+        if class_code:
+            try:
+                classroom = Classroom.objects.get(code=class_code)
+            except Classroom.DoesNotExist:
+                raise CommandError(f"Classroom with code '{class_code}' not found")
+
+        created = 0
+        for pseudonym in options["pseudonyms"]:
+            user, was_created = User.objects.get_or_create(
+                pseudonym=pseudonym,
+                defaults={"classroom": classroom}
+            )
+            if was_created:
+                created += 1
+        self.stdout.write(self.style.SUCCESS(f"Created {created} students"))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -194,13 +194,25 @@ class NextStepSuggestAPITests(APITestCase):
 class LoginWorkflowTests(APITestCase):
     def setUp(self):
         self.classroom = Classroom.objects.create(name="10A", code="abc", use_ai=True)
+        self.alice = User.objects.create_user(pseudonym="alice")
+        self.bob = User.objects.create_user(pseudonym="bob")
 
     def test_login_assigns_classroom(self):
-        resp = self.client.post("/api/login/", {"pseudonym": "alice", "class_code": "abc"}, format="json")
+        resp = self.client.post(
+            "/api/login/", {"pseudonym": "alice", "class_code": "abc"}, format="json"
+        )
         self.assertEqual(resp.status_code, 200)
-        user = User.objects.get(pseudonym="alice")
-        self.assertEqual(user.classroom, self.classroom)
+        self.alice.refresh_from_db()
+        self.assertEqual(self.alice.classroom, self.classroom)
 
     def test_login_missing_classroom(self):
-        resp = self.client.post("/api/login/", {"pseudonym": "bob", "class_code": "wrong"}, format="json")
+        resp = self.client.post(
+            "/api/login/", {"pseudonym": "bob", "class_code": "wrong"}, format="json"
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_login_unknown_user(self):
+        resp = self.client.post(
+            "/api/login/", {"pseudonym": "unknown"}, format="json"
+        )
         self.assertEqual(resp.status_code, 400)


### PR DESCRIPTION
## Summary
- Stop automatically creating users in `LoginView` and `login_page`; return errors for unknown pseudonyms
- Add `create_students` management command to bulk create student accounts
- Extend login workflow tests to cover unknown pseudonym failures

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689dd3bb60b483248ca50a56262fb078