### PR TITLE
Add admin dashboard with export stats and links

### DIFF
--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from exports.admin import DashboardView
 from accounts.views import (
     login_page,
     dashboard,
@@ -24,6 +25,7 @@ from accounts.views import (
 )
 
 urlpatterns = [
+    path("admin/exports/dashboard/", DashboardView.as_view(), name="exports-dashboard"),
     path("admin/", admin.site.urls),
     path("", login_page, name="login"),
     path("dashboard/", dashboard, name="dashboard"),

--- a/src/exports/admin.py
+++ b/src/exports/admin.py
@@ -1,0 +1,20 @@
+from django.contrib import admin
+from django.contrib.admin.views.decorators import staff_member_required
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+
+class DashboardView(TemplateView):
+    """Simple dashboard view embedded into the Django admin."""
+
+    template_name = "exports/admin_dashboard.html"
+
+    @method_decorator(staff_member_required)
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Reuse default admin context for consistent styling
+        context.update(admin.site.each_context(self.request))
+        return context

--- a/src/exports/urls.py
+++ b/src/exports/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
-from .views import ExportCSVView, ExportXLSXView
+from .views import ExportCSVView, ExportXLSXView, DashboardDataView
+
+app_name = "exports"
 
 urlpatterns = [
-    path('export/csv/', ExportCSVView.as_view()),
-    path('export/xlsx/', ExportXLSXView.as_view()),
+    path('export/csv/', ExportCSVView.as_view(), name="csv"),
+    path('export/xlsx/', ExportXLSXView.as_view(), name="xlsx"),
+    path('export/dashboard-data/', DashboardDataView.as_view(), name="dashboard-data"),
 ]

--- a/templates/exports/admin_dashboard.html
+++ b/templates/exports/admin_dashboard.html
@@ -1,0 +1,39 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<h1>Exports Dashboard</h1>
+
+<div style="max-width:600px">
+  <canvas id="group-chart"></canvas>
+</div>
+<div style="max-width:600px">
+  <canvas id="ki-chart"></canvas>
+</div>
+
+<p>
+  <a href="{% url 'exports:csv' %}">CSV Export</a> |
+  <a href="{% url 'exports:xlsx' %}">XLSX Export</a>
+</p>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+fetch("{% url 'exports:dashboard-data' %}")
+  .then(response => response.json())
+  .then(data => {
+    new Chart(document.getElementById('group-chart'), {
+      type: 'bar',
+      data: {
+        labels: data.group_labels,
+        datasets: [{label: 'Goals per group', data: data.group_data}]
+      }
+    });
+    new Chart(document.getElementById('ki-chart'), {
+      type: 'doughnut',
+      data: {
+        labels: data.ki_labels,
+        datasets: [{data: data.ki_data}]
+      }
+    });
+  });
+</script>
+{% endblock %}

--- a/tests/test_admin_dashboard.py
+++ b/tests/test_admin_dashboard.py
@@ -1,0 +1,43 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from lessons.models import LessonSession, UserSession, Classroom
+from goals.models import Goal, KIInteraction
+
+
+class AdminDashboardTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.staff = User.objects.create_user(
+            pseudonym="staff", password="pw", is_staff=True, gruppe=User.KG
+        )
+        self.user = User.objects.create_user(
+            pseudonym="u1", password="pw", is_staff=False, gruppe=User.VG
+        )
+        classroom = Classroom.objects.create(name="10A")
+        lesson = LessonSession.objects.create(date="2024-01-01", classroom=classroom)
+        staff_session = UserSession.objects.create(user=self.staff, lesson_session=lesson)
+        user_session = UserSession.objects.create(user=self.user, lesson_session=lesson)
+        Goal.objects.create(user_session=staff_session, raw_text="g1")
+        goal_with_ki = Goal.objects.create(user_session=user_session, raw_text="g2")
+        KIInteraction.objects.create(goal=goal_with_ki, turn=1, role="user", content="hi")
+        self.client.force_login(self.staff)
+
+    def test_dashboard_requires_staff(self):
+        resp = self.client.get("/admin/exports/dashboard/")
+        self.assertEqual(resp.status_code, 200)
+        self.client.logout()
+        self.client.force_login(self.user)
+        resp = self.client.get("/admin/exports/dashboard/")
+        self.assertEqual(resp.status_code, 302)
+
+    def test_data_endpoint_structure_and_access(self):
+        resp = self.client.get("/api/export/dashboard-data/")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        for key in ["group_labels", "group_data", "ki_labels", "ki_data"]:
+            self.assertIn(key, data)
+        self.client.logout()
+        self.client.force_login(self.user)
+        resp = self.client.get("/api/export/dashboard-data/")
+        self.assertEqual(resp.status_code, 302)


### PR DESCRIPTION
## Summary
- Add staff-only admin dashboard with Chart.js charts and export links
- Expose JSON stats endpoint and wire existing export views into admin
- Test access control and response structure for dashboard features

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689dd521a6348324bc88a4df661cd410