### PR TITLE
Connect lesson sessions to classrooms

### DIFF
--- a/src/accounts/management/commands/seed_demo.py
+++ b/src/accounts/management/commands/seed_demo.py
@@ -1,15 +1,22 @@
 from django.core.management.base import BaseCommand
 from accounts.models import User
-from lessons.models import LessonSession
+from lessons.models import LessonSession, Classroom
 from django.utils import timezone
 
 class Command(BaseCommand):
     help = "Seed demo users and a lesson session"
 
     def handle(self, *args, **options):
-        User.objects.get_or_create(pseudonym="alice", defaults={"gruppe": User.VG})
-        User.objects.get_or_create(pseudonym="bob", defaults={"gruppe": User.KG})
+        classroom, _ = Classroom.objects.get_or_create(name="Demo", defaults={"use_ai": True})
+        User.objects.get_or_create(
+            pseudonym="alice", defaults={"gruppe": User.VG, "classroom": classroom}
+        )
+        User.objects.get_or_create(
+            pseudonym="bob", defaults={"gruppe": User.KG, "classroom": classroom}
+        )
         LessonSession.objects.get_or_create(
-            date=timezone.now().date(), defaults={"topic": "Demo", "use_ai": True}
+            date=timezone.now().date(),
+            classroom=classroom,
+            defaults={"topic": "Demo", "use_ai": True},
         )
         self.stdout.write(self.style.SUCCESS("Demo data created"))

--- a/tests/test_next_steps.py
+++ b/tests/test_next_steps.py
@@ -3,15 +3,16 @@ from unittest.mock import patch
 from rest_framework.test import APITestCase
 
 from accounts.models import User
-from lessons.models import LessonSession, UserSession
+from lessons.models import LessonSession, UserSession, Classroom
 from goals.models import Goal
 from reflections.models import Reflection
 
 
 class NextStepSuggestTests(APITestCase):
     def setUp(self):
-        self.lesson = LessonSession.objects.create(date="2024-01-01", use_ai=True)
-        self.user = User.objects.create_user(pseudonym="vg", gruppe=User.VG)
+        self.classroom = Classroom.objects.create(name="10A", use_ai=True)
+        self.lesson = LessonSession.objects.create(date="2024-01-01", classroom=self.classroom)
+        self.user = User.objects.create_user(pseudonym="vg", gruppe=User.VG, classroom=self.classroom)
         self.session = UserSession.objects.create(user=self.user, lesson_session=self.lesson)
         self.goal = Goal.objects.create(
             user_session=self.session, raw_text="Test", final_text="Test"


### PR DESCRIPTION
## Summary
- Ensure demo data uses classrooms and attaches lesson sessions to them
- Update next-step tests to create classroom-specific sessions

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_689dd6cdc2288324bf0693bad8ff6069