### PR TITLE
Rename SMART score key to overall

### DIFF
--- a/src/exports/views.py
+++ b/src/exports/views.py
@@ -51,7 +51,7 @@ def build_dataset(from_date=None, to_date=None, klass=None, group=None):
             "smart_achievable": smart.get("achievable"),
             "smart_relevant": smart.get("relevant"),
             "smart_time_bound": smart.get("time_bound"),
-            "smart_score": smart.get("score"),
+            "smart_score": smart.get("overall", smart.get("score")),
             "ref_result": getattr(reflection, "result", None),
             "ref_obstacles": getattr(reflection, "obstacles", None),
             "ref_next_step": getattr(reflection, "next_step", None),

--- a/src/goals/migrations/0003_rename_score_to_overall.py
+++ b/src/goals/migrations/0003_rename_score_to_overall.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def rename_score_to_overall(apps, schema_editor):
+    Goal = apps.get_model('goals', 'Goal')
+    for goal in Goal.objects.exclude(smart_score__isnull=True):
+        smart = goal.smart_score
+        if isinstance(smart, dict) and 'score' in smart and 'overall' not in smart:
+            smart['overall'] = smart.pop('score')
+            goal.smart_score = smart
+            goal.save(update_fields=['smart_score'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('goals', '0002_overallgoal'),
+    ]
+
+    operations = [
+        migrations.RunPython(rename_score_to_overall, migrations.RunPython.noop),
+    ]

--- a/src/goals/services.py
+++ b/src/goals/services.py
@@ -54,7 +54,7 @@ def evaluate_smart(text: str, topic: str, client: Optional[OpenAI] = None) -> di
             "achievable": False,
             "relevant": False,
             "time_bound": False,
-            "score": 0,
+            "overall": 0,
             "question": "(KI nicht verfügbar) Bitte formuliere dein Ziel genauer.",
         }
 
@@ -73,14 +73,14 @@ def evaluate_smart(text: str, topic: str, client: Optional[OpenAI] = None) -> di
             "achievable": False,
             "relevant": False,
             "time_bound": False,
-            "score": 0,
+            "overall": 0,
             "question": "(Fehler bei KI) Bitte versuche es erneut.",
         }
 
     for key in ["specific", "measurable", "achievable", "relevant", "time_bound"]:
         data[key] = bool(data.get(key))
 
-    data["score"] = sum(
+    data["overall"] = sum(
         data[k]
         for k in ["specific", "measurable", "achievable", "relevant", "time_bound"]
     )

--- a/src/goals/views.py
+++ b/src/goals/views.py
@@ -65,10 +65,10 @@ class CoachNextView(APIView):
             "achievable",
             "relevant",
             "time_bound",
-            "score",
+            "overall",
         ]}
         goal.save()
-        if result["score"] == 5:
+        if result["overall"] == 5:
             answer = coach.finalize(goal, topic)
             status_flag = "ready_to_finalize"
         else:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -28,7 +28,15 @@
         <tr class="border-t">
             <td class="px-2 py-1">{{ goal.final_text|default:goal.raw_text }}</td>
             <td class="px-2 py-1">{{ goal.user_session.lesson_session.date }}</td>
-            <td class="px-2 py-1">{% if goal.smart_score %}{{ goal.smart_score.overall }}{% else %}-{% endif %}</td>
+            <td class="px-2 py-1">
+                {% if goal.smart_score %}
+                    {% if goal.smart_score.overall %}
+                        {{ goal.smart_score.overall }}
+                    {% elif goal.smart_score.score %}
+                        {{ goal.smart_score.score }}
+                    {% else %}-{% endif %}
+                {% else %}-{% endif %}
+            </td>
             <td class="px-2 py-1">{% if reflection %}{{ reflection.get_result_display }}{% else %}-{% endif %}</td>
         </tr>
         {% endwith %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,7 +88,7 @@ class AiCoachPromptTests(APITestCase):
             "achievable": True,
             "relevant": True,
             "time_bound": True,
-            "score": 5,
+            "overall": 5,
             "question": "",
         }
         mock_ask.return_value = "Final"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -55,7 +55,7 @@ def test_evaluate_smart_llm_parsing():
     }
     client = DummyClient(payload)
     result = evaluate_smart("Ich möchte besser rechnen", "Mathe", client=client)
-    assert result["score"] == 3
+    assert result["overall"] == 3
     assert result["question"] == "Wie kannst du dein Ziel messbar machen?"
     assert result["measurable"] is False
 


### PR DESCRIPTION
## Summary
- rename SMART evaluation result field from `score` to `overall`
- update templates, services, views and tests to use `goal.smart_score.overall`
- migrate existing `smart_score` entries and provide fallback in exports and dashboard

## Testing
- `PYTHONPATH=src DJANGO_SETTINGS_MODULE=config.settings pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ddbf558b08324bc75b011a06009e4