### PR TITLE
Restrict AI suggestions to VG users

### DIFF
--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from accounts.models import User
+from lessons.models import Classroom
+
+
+class ReflectionAiToggleTests(TestCase):
+    def setUp(self):
+        self.classroom = Classroom.objects.create(name="10A", use_ai=True)
+        self.user = User.objects.create_user(pseudonym="kg", gruppe=User.KG, classroom=self.classroom)
+        self.client.force_login(self.user)
+
+    def test_kg_user_does_not_see_ai_button(self):
+        response = self.client.get(reverse("reflection"))
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["can_use_ai"])
+        self.assertNotIn("KI-Vorschläge anzeigen", response.content.decode())


### PR DESCRIPTION
## Summary
- Add test ensuring KG users do not see AI suggestion button on reflection page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689dddfba3c08324a83364fabf06575f