### PR TITLE
Include overall goals in exports

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 
 from lessons.models import LessonSession, UserSession, Classroom
-from goals.models import Goal, KIInteraction
+from goals.models import Goal, KIInteraction, OverallGoal
 from reflections.models import Reflection, Note
 import openpyxl
 
@@ -26,6 +26,8 @@ class ExportViewTests(TestCase):
         self.goal1 = Goal.objects.create(user_session=self.session1, raw_text="g1")
         self.goal2 = Goal.objects.create(user_session=self.session2, raw_text="g2")
         self.goal3 = Goal.objects.create(user_session=self.session3, raw_text="g3")
+        OverallGoal.objects.create(user=self.user1, text="old overall")
+        OverallGoal.objects.create(user=self.user1, text="new overall")
         Reflection.objects.create(user_session=self.session2, goal=self.goal2, result="yes", obstacles="none", next_step="next", next_step_source="user")
         Note.objects.create(user_session=self.session2, content="note")
         KIInteraction.objects.create(goal=self.goal2, turn=1, role="user", content="hi")
@@ -37,12 +39,19 @@ class ExportViewTests(TestCase):
         self.assertIn("g2", content)
         self.assertNotIn("g1", content)
         self.assertNotIn("g3", content)
+        self.assertIn("new overall", content)
 
     def test_xlsx_contains_sheets_and_exported_at(self):
         resp = self.client.get("/api/export/xlsx/")
         self.assertEqual(resp.status_code, 200)
         wb = openpyxl.load_workbook(BytesIO(resp.content))
-        self.assertEqual(set(wb.sheetnames), {"Users", "Goals", "Reflections", "KIInteractions", "Notes", "flat_dataset"})
+        self.assertEqual(set(wb.sheetnames), {"Users", "Goals", "Reflections", "KIInteractions", "Notes", "OverallGoals", "flat_dataset"})
         ws = wb["flat_dataset"]
         headers = [cell.value for cell in next(ws.iter_rows(max_row=1))]
         self.assertIn("exported_at", headers)
+        self.assertIn("overall_goal", headers)
+        data_row = [cell.value for cell in next(ws.iter_rows(min_row=2, max_row=2))]
+        self.assertIn("new overall", data_row)
+        ws_goals = wb["OverallGoals"]
+        og_headers = [cell.value for cell in next(ws_goals.iter_rows(max_row=1))]
+        self.assertIn("exported_at", og_headers)


### PR DESCRIPTION
## Summary
- Add user's latest overall goal to each row in exports
- Provide separate `OverallGoals` sheet in XLSX export
- Extend tests for CSV and XLSX outputs

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689de18927a88324a38a226ee34f49ab