### PR TITLE
Show reflection link for non-AI users on dashboard

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -38,6 +38,7 @@
     <a href="{% url 'reflection' %}" class="bg-blue-500 text-white px-4 py-2 text-center w-full sm:w-auto">Reflexion starten</a>
     {% else %}
     <a href="{% url 'goal_kg' %}" class="bg-green-500 text-white px-4 py-2 text-center w-full sm:w-auto">Ziel setzen</a>
+    <a href="{% url 'reflection' %}" class="bg-blue-500 text-white px-4 py-2 text-center w-full sm:w-auto">Reflexion starten</a>
     {% endif %}
 </div>
 {% if goals %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -37,14 +37,29 @@ class DashboardAiToggleTests(TestCase):
         )
         self.client.force_login(self.user)
 
-    def test_ai_buttons_hidden_when_disabled(self):
+    def test_reflection_button_visible_when_ai_disabled(self):
         settings = SiteSettings.get()
         settings.allow_ai = False
         settings.save()
         response = self.client.get(reverse("dashboard"))
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context["can_use_ai"])
-        self.assertNotIn("Reflexion starten", response.content.decode())
+        self.assertIn("Reflexion starten", response.content.decode())
+
+
+class DashboardKgReflectionLinkTests(TestCase):
+    def setUp(self):
+        self.classroom = Classroom.objects.create(name="10A", use_ai=True)
+        self.user = User.objects.create_user(
+            pseudonym="kg1", gruppe=User.KG, classroom=self.classroom
+        )
+        self.client.force_login(self.user)
+
+    def test_kg_user_sees_reflection_link(self):
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["can_use_ai"])
+        self.assertIn("Reflexion starten", response.content.decode())
 
 
 class DashboardOverallGoalTests(TestCase):


### PR DESCRIPTION
## Summary
- show "Reflexion starten" button on dashboard when AI features are unavailable
- add tests ensuring button visibility for KG users and when AI is disabled

## Testing
- `python manage.py test tests.test_dashboard -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689de8d9e0148324ba40c2ef7e2ad978