### PR TITLE
Remove unused notes functionality

### DIFF
--- a/src/reflections/admin.py
+++ b/src/reflections/admin.py
@@ -1,11 +1,8 @@
 from django.contrib import admin
-from .models import Reflection, Note
+from .models import Reflection
+
 
 @admin.register(Reflection)
 class ReflectionAdmin(admin.ModelAdmin):
     list_display = ("user_session", "goal", "result", "created_at")
     list_filter = ("result",)
-
-@admin.register(Note)
-class NoteAdmin(admin.ModelAdmin):
-    list_display = ("user_session", "created_at")

--- a/src/reflections/migrations/0001_initial.py
+++ b/src/reflections/migrations/0001_initial.py
@@ -16,29 +16,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name="Note",
-            fields=[
-                (
-                    "id",
-                    models.UUIDField(
-                        default=uuid.uuid4,
-                        editable=False,
-                        primary_key=True,
-                        serialize=False,
-                    ),
-                ),
-                ("content", models.TextField()),
-                ("created_at", models.DateTimeField(auto_now_add=True)),
-                (
-                    "user_session",
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="lessons.usersession",
-                    ),
-                ),
-            ],
-        ),
-        migrations.CreateModel(
             name="Reflection",
             fields=[
                 (

--- a/src/reflections/models.py
+++ b/src/reflections/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from goals.models import Goal
 from lessons.models import UserSession
 
+
 class Reflection(models.Model):
     RESULT_CHOICES = [("yes", "Ja"), ("partial", "Teilweise"), ("no", "Nein")]
 
@@ -15,11 +16,4 @@ class Reflection(models.Model):
     obstacles = models.TextField()
     next_step = models.TextField()
     next_step_source = models.CharField(max_length=10, default="user")
-    created_at = models.DateTimeField(auto_now_add=True)
-
-
-class Note(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    user_session = models.ForeignKey(UserSession, on_delete=models.CASCADE)
-    content = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)

--- a/src/reflections/serializers.py
+++ b/src/reflections/serializers.py
@@ -1,14 +1,18 @@
 from rest_framework import serializers
-from .models import Reflection, Note
+from .models import Reflection
+
 
 class ReflectionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Reflection
-        fields = ["id", "user_session", "goal", "result", "obstacles", "next_step", "next_step_source", "created_at"]
-        read_only_fields = ["created_at"]
-
-class NoteSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Note
-        fields = ["id", "user_session", "content", "created_at"]
+        fields = [
+            "id",
+            "user_session",
+            "goal",
+            "result",
+            "obstacles",
+            "next_step",
+            "next_step_source",
+            "created_at",
+        ]
         read_only_fields = ["created_at"]

--- a/src/reflections/urls.py
+++ b/src/reflections/urls.py
@@ -1,8 +1,7 @@
 from django.urls import path
-from .views import ReflectionCreateView, NoteCreateView, NextStepSuggestView
+from .views import ReflectionCreateView, NextStepSuggestView
 
 urlpatterns = [
     path('reflections/', ReflectionCreateView.as_view()),
-    path('notes/', NoteCreateView.as_view()),
     path('vg/next-step/suggest/', NextStepSuggestView.as_view()),
 ]

--- a/src/reflections/views.py
+++ b/src/reflections/views.py
@@ -6,8 +6,8 @@ from rest_framework.response import Response
 from rest_framework.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 
-from .models import Reflection, Note
-from .serializers import ReflectionSerializer, NoteSerializer
+from .models import Reflection
+from .serializers import ReflectionSerializer
 from goals.permissions import IsVGUser
 from goals.models import Goal
 from goals.services import suggest_next_steps
@@ -24,17 +24,6 @@ class ReflectionCreateView(generics.CreateAPIView):
             user_session.user != self.request.user
             or goal.user_session.user != self.request.user
         ):
-            raise PermissionDenied()
-        serializer.save()
-
-
-class NoteCreateView(generics.CreateAPIView):
-    queryset = Note.objects.all()
-    serializer_class = NoteSerializer
-
-    def perform_create(self, serializer):
-        user_session = serializer.validated_data["user_session"]
-        if user_session.user != self.request.user:
             raise PermissionDenied()
         serializer.save()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -427,9 +427,3 @@ class OwnershipAPITests(APITestCase):
         resp = self.client.post("/api/reflections/", data)
         self.assertEqual(resp.status_code, 403)
 
-    def test_note_requires_own_session(self):
-        self.client.force_login(self.user_vg1)
-        resp = self.client.post(
-            "/api/notes/", {"user_session": str(self.session_vg2.id), "content": "h"}
-        )
-        self.assertEqual(resp.status_code, 403)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 
 from lessons.models import LessonSession, UserSession, Classroom
 from goals.models import Goal, KIInteraction, OverallGoal
-from reflections.models import Reflection, Note
+from reflections.models import Reflection
 import openpyxl
 
 
@@ -28,8 +28,14 @@ class ExportViewTests(TestCase):
         self.goal3 = Goal.objects.create(user_session=self.session3, raw_text="g3")
         OverallGoal.objects.create(user=self.user1, text="old overall")
         OverallGoal.objects.create(user=self.user1, text="new overall")
-        Reflection.objects.create(user_session=self.session2, goal=self.goal2, result="yes", obstacles="none", next_step="next", next_step_source="user")
-        Note.objects.create(user_session=self.session2, content="note")
+        Reflection.objects.create(
+            user_session=self.session2,
+            goal=self.goal2,
+            result="yes",
+            obstacles="none",
+            next_step="next",
+            next_step_source="user",
+        )
         KIInteraction.objects.create(goal=self.goal2, turn=1, role="user", content="hi")
 
     def test_csv_filters(self):
@@ -45,7 +51,10 @@ class ExportViewTests(TestCase):
         resp = self.client.get("/api/export/xlsx/")
         self.assertEqual(resp.status_code, 200)
         wb = openpyxl.load_workbook(BytesIO(resp.content))
-        self.assertEqual(set(wb.sheetnames), {"Users", "Goals", "Reflections", "KIInteractions", "Notes", "OverallGoals", "flat_dataset"})
+        self.assertEqual(
+            set(wb.sheetnames),
+            {"Users", "Goals", "Reflections", "KIInteractions", "OverallGoals", "flat_dataset"},
+        )
         ws = wb["flat_dataset"]
         headers = [cell.value for cell in next(ws.iter_rows(max_row=1))]
         self.assertIn("exported_at", headers)


### PR DESCRIPTION
## Summary
- remove unused Note model, serializer, and API endpoints
- drop note-related exports and update tests

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689df2c0aea0832492cf3da2037dc27a