### PR TITLE
Require authentication for overall goal API

### DIFF
--- a/src/goals/views.py
+++ b/src/goals/views.py
@@ -15,6 +15,7 @@ from lessons.models import UserSession
 
 
 class OverallGoalView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
     def get(self, request):
         goal = OverallGoal.objects.filter(user=request.user).first()
         if not goal:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,6 +67,14 @@ class OverallGoalAPITests(APITestCase):
         self.assertEqual(goal.text, "Neu")
 
 
+class OverallGoalPermissionTests(APITestCase):
+    def test_requires_authentication(self):
+        resp = self.client.get("/api/overall-goal/")
+        self.assertEqual(resp.status_code, 403)
+        resp = self.client.post("/api/overall-goal/", {"text": "x"})
+        self.assertEqual(resp.status_code, 403)
+
+
 class GoalFinalizeTests(APITestCase):
     def setUp(self):
         self.classroom = Classroom.objects.create(name="10A", use_ai=True)


### PR DESCRIPTION
## Summary
- enforce authentication on `OverallGoalView`
- add tests ensuring unauthenticated requests to `/api/overall-goal/` return 403

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689df681190c8324a60504334c5944c6