### PR TITLE
Handle reflection without goal

### DIFF
--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -66,6 +66,7 @@ def dashboard(request):
         and lesson.use_ai
         and SiteSettings.get().allow_ai
     )
+    current_goal = Goal.objects.filter(user_session=user_session).first()
     goals = (
         Goal.objects
         .filter(user_session__user=request.user)
@@ -94,6 +95,7 @@ def dashboard(request):
             "user": request.user,
             "user_session_id": user_session.id,
             "can_use_ai": can_use_ai,
+            "current_goal": current_goal,
             "goals": goals,
             "overall_goal": overall_goal,
             "completed_goals": completed,
@@ -137,6 +139,8 @@ def reflection_page(request):
     lesson, _ = LessonSession.objects.get_or_create(date=today, classroom=request.user.classroom)
     user_session, _ = UserSession.objects.get_or_create(user=request.user, lesson_session=lesson)
     goal = Goal.objects.filter(user_session=user_session).first()
+    if goal is None:
+        return redirect("dashboard")
     can_use_ai = (
         request.user.gruppe == User.VG
         and lesson.use_ai

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -35,9 +35,10 @@
 <div class="flex flex-col sm:flex-row gap-2" id="goal-section">
     {% if can_use_ai %}
     <a href="{% url 'goal_vg' %}" class="bg-green-500 text-white px-4 py-2 text-center w-full sm:w-auto">Ziel setzen</a>
-    <a href="{% url 'reflection' %}" class="bg-blue-500 text-white px-4 py-2 text-center w-full sm:w-auto">Reflexion starten</a>
     {% else %}
     <a href="{% url 'goal_kg' %}" class="bg-green-500 text-white px-4 py-2 text-center w-full sm:w-auto">Ziel setzen</a>
+    {% endif %}
+    {% if current_goal %}
     <a href="{% url 'reflection' %}" class="bg-blue-500 text-white px-4 py-2 text-center w-full sm:w-auto">Reflexion starten</a>
     {% endif %}
 </div>

--- a/templates/reflection.html
+++ b/templates/reflection.html
@@ -5,7 +5,7 @@
     <form x-show="!submitted"
           hx-post="/api/reflections/"
           hx-swap="none"
-          @htmx:afterRequest="submitted=true; setTimeout(()=>window.location.href='{% url 'dashboard' %}',1500)"
+          @htmx:afterRequest="handleResponse"
           class="space-y-2">
         <input type="hidden" name="user_session" value="{{ user_session_id }}">
         <input type="hidden" name="goal" value="{{ goal_id }}">
@@ -31,7 +31,7 @@
                         :hx-vals="{selected: s}"
                         hx-include="closest form"
                         hx-swap="none"
-                        @htmx:afterRequest="submitted=true; setTimeout(()=>window.location.href='{% url 'dashboard' %}',1500)"
+                        @htmx:afterRequest="handleResponse"
                         x-text="s"></button>
             </template>
         </div>
@@ -39,16 +39,27 @@
         <button class="bg-blue-500 text-white px-4 py-2 w-full sm:w-auto">Reflexion speichern</button>
     </form>
     <div x-show="submitted" class="p-4 bg-green-100 rounded">Danke für deine Reflexion!</div>
+    <div x-show="error" class="p-4 bg-red-100 rounded" x-text="error"></div>
 </div>
 <script>
 function reflectionForm(){
     return {
         suggestions: [],
         submitted: false,
+        error: '',
         handleSuggestions(e){
             let data = {};
             try { data = JSON.parse(e.detail.xhr.responseText); } catch(err){}
             this.suggestions = data.suggestions || [];
+        },
+        handleResponse(e){
+            if(e.detail.xhr.status >= 200 && e.detail.xhr.status < 300){
+                this.error = '';
+                this.submitted = true;
+                setTimeout(()=>window.location.href='{% url 'dashboard' %}',1500);
+            } else {
+                this.error = 'Beim Speichern ist ein Fehler aufgetreten.';
+            }
         }
     }
 }

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 from accounts.models import User
-from lessons.models import Classroom
+from lessons.models import Classroom, LessonSession, UserSession
+from goals.models import Goal
 
 
 class ReflectionAiToggleTests(TestCase):
@@ -10,9 +12,34 @@ class ReflectionAiToggleTests(TestCase):
         self.classroom = Classroom.objects.create(name="10A", use_ai=True)
         self.user = User.objects.create_user(pseudonym="kg", gruppe=User.KG, classroom=self.classroom)
         self.client.force_login(self.user)
+        lesson = LessonSession.objects.create(date=timezone.now().date(), classroom=self.classroom)
+        session = UserSession.objects.create(user=self.user, lesson_session=lesson)
+        Goal.objects.create(user_session=session, raw_text="test")
 
     def test_kg_user_does_not_see_ai_button(self):
         response = self.client.get(reverse("reflection"))
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context["can_use_ai"])
         self.assertNotIn("KI-Vorschläge anzeigen", response.content.decode())
+
+
+class ReflectionEdgeCaseTests(TestCase):
+    def setUp(self):
+        self.classroom = Classroom.objects.create(name="10A")
+        self.user = User.objects.create_user(pseudonym="u1", classroom=self.classroom)
+        self.client.force_login(self.user)
+
+    def test_redirect_without_goal(self):
+        response = self.client.get(reverse("reflection"))
+        self.assertRedirects(response, reverse("dashboard"))
+
+    def test_validation_error(self):
+        lesson = LessonSession.objects.create(date=timezone.now().date(), classroom=self.classroom)
+        session = UserSession.objects.create(user=self.user, lesson_session=lesson)
+        goal = Goal.objects.create(user_session=session, raw_text="test")
+        resp = self.client.post(
+            "/api/reflections/",
+            {"user_session": str(session.id), "goal": str(goal.id)},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("result", resp.json())


### PR DESCRIPTION
## Summary
- Redirect users to the dashboard when opening the reflection page without an active goal
- Show the "Reflexion starten" link on the dashboard only when a current goal exists
- Improve reflection submission to display success on 2xx responses and an error on failures
- Cover edge cases with new tests for missing goals and validation errors

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689df7ebb4988324a11472b5b607b371