### PR TITLE
Add logout view and navigation header

### DIFF
--- a/src/accounts/urls.py
+++ b/src/accounts/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import LoginView, MeView
+from .views import LoginView, MeView, logout_view
 
 urlpatterns = [
     path('login/', LoginView.as_view(), name='api-login'),
     path('me/', MeView.as_view(), name='me'),
+    path('logout/', logout_view, name='api-logout'),
 ]

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.contrib.auth import login
+from django.contrib.auth import login, logout
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
 from django.http import HttpResponseForbidden
@@ -49,6 +49,12 @@ class LoginView(APIView):
         user.backend = "django.contrib.auth.backends.ModelBackend"
         login(request, user)
         return Response(UserSerializer(user).data)
+
+
+def logout_view(request):
+    """Log the user out and redirect to the login page."""
+    logout(request)
+    return redirect("login")
 
 
 class MeView(APIView):

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -23,6 +23,7 @@ from accounts.views import (
     goal_kg_page,
     reflection_page,
     overall_goal_page,
+    logout_view,
 )
 
 urlpatterns = [
@@ -34,6 +35,7 @@ urlpatterns = [
     path("goal/kg/", goal_kg_page, name="goal_kg"),
     path("reflection/", reflection_page, name="reflection"),
     path("overall-goal/", overall_goal_page, name="overall_goal"),
+    path("logout/", logout_view, name="logout"),
     path("api/", include("accounts.urls")),
     path("api/", include("lessons.urls")),
     path("api/", include("goals.urls")),

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,14 @@
     <title>{% block title %}SRL Platform{% endblock %}</title>
 </head>
 <body class="p-4 max-w-xl mx-auto">
+    {% if request.user.is_authenticated %}
+    <header class="mb-4">
+        <nav class="flex gap-4">
+            <a href="{% url 'dashboard' %}">Dashboard</a>
+            <a href="{% url 'logout' %}">Logout</a>
+        </nav>
+    </header>
+    {% endif %}
     {% block content %}{% endblock %}
 </body>
 </html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -144,3 +144,15 @@ class DashboardProgressTests(TestCase):
         self.assertEqual(response.context["open_goals"], 1)
         self.assertEqual(response.context["completion_rate"], 50)
         self.assertContains(response, "progressChart")
+
+
+class LogoutTests(TestCase):
+    def setUp(self):
+        self.classroom = Classroom.objects.create(name="10A")
+        self.user = User.objects.create_user(pseudonym="u1", classroom=self.classroom)
+        self.client.force_login(self.user)
+
+    def test_logout_redirects_and_clears_session(self):
+        response = self.client.get(reverse("logout"))
+        self.assertRedirects(response, reverse("login"))
+        self.assertNotIn("_auth_user_id", self.client.session)


### PR DESCRIPTION
## Summary
- add logout view using Django's auth.logout
- wire up `/logout/` routes and navigation header
- test logout behavior

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689dfa0e36408324bf295bd4af0675d9