### PR TITLE
Add dashboard redirects after goal completion

### DIFF
--- a/templates/goal_kg.html
+++ b/templates/goal_kg.html
@@ -21,6 +21,7 @@ function goalKG(){
             let data={};
             try{ data = JSON.parse(e.detail.xhr.responseText);}catch(err){}
             if(data.smart_score){ this.smart = data.smart_score; }
+            if(e.detail.successful){ window.location.href='/dashboard/'; }
         }
     }
 }

--- a/templates/goal_vg.html
+++ b/templates/goal_vg.html
@@ -46,6 +46,7 @@ function goalCoach(){
                 }).then(r=>r.json()).then(res=>{
                     if(res.final_text){ this.addMessage('assistant', res.final_text); }
                     if(res.smart_score){ this.smart = res.smart_score; }
+                    window.location.href='/dashboard/';
                 });
             }
         },

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,0 +1,66 @@
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.support.ui import WebDriverWait
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.options import Options
+
+from accounts.models import User
+from lessons.models import Classroom
+
+
+class GoalRedirectTests(StaticLiveServerTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        try:
+            options = Options()
+            options.add_argument("--headless=new")
+            options.add_argument("--no-sandbox")
+            options.add_argument("--disable-dev-shm-usage")
+            options.binary_location = "/usr/bin/chromium-browser"
+            service = Service(ChromeDriverManager().install())
+            cls.selenium = webdriver.Chrome(service=service, options=options)
+            cls.selenium.implicitly_wait(10)
+        except Exception:
+            cls.selenium = None
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.selenium:
+            cls.selenium.quit()
+        super().tearDownClass()
+
+    def _login(self, user):
+        self.client.force_login(user)
+        cookie = self.client.cookies['sessionid']
+        self.selenium.get(self.live_server_url + reverse('login'))
+        self.selenium.add_cookie({'name': 'sessionid', 'value': cookie.value, 'path': '/'})
+
+    def test_goal_kg_redirect(self):
+        if not self.selenium:
+            self.skipTest("Webdriver not available")
+        classroom = Classroom.objects.create(name="10A")
+        user = User.objects.create_user(pseudonym="kg1", gruppe=User.KG, classroom=classroom)
+        self._login(user)
+        self.selenium.get(self.live_server_url + reverse('goal_kg'))
+        textarea = self.selenium.find_element(By.NAME, "raw_text")
+        textarea.send_keys("Testziel")
+        self.selenium.find_element(By.CSS_SELECTOR, "form button").click()
+        WebDriverWait(self.selenium, 5).until(lambda d: d.current_url.endswith('/dashboard/'))
+
+    def test_goal_vg_redirect(self):
+        if not self.selenium:
+            self.skipTest("Webdriver not available")
+        classroom = Classroom.objects.create(name="10A", use_ai=True)
+        user = User.objects.create_user(pseudonym="vg1", gruppe=User.VG, classroom=classroom)
+        self._login(user)
+        self.selenium.get(self.live_server_url + reverse('goal_vg'))
+        textarea = self.selenium.find_element(By.TAG_NAME, "textarea")
+        textarea.send_keys("Test")
+        self.selenium.find_element(By.CSS_SELECTOR, "form button").click()
+        WebDriverWait(self.selenium, 5).until(lambda d: d.execute_script("return document.querySelector('[x-data]').__x.$data.goalId !== null"))
+        self.selenium.execute_script("document.querySelector('[x-data]').__x.$data.handleResponse({detail:{xhr:{responseText:'{\"message_type\":\"ready_to_finalize\"}'}}});")
+        WebDriverWait(self.selenium, 5).until(lambda d: d.current_url.endswith('/dashboard/'))


### PR DESCRIPTION
## Summary
- Redirect KG goal creation to dashboard upon success
- Redirect VG goal finalization to dashboard
- Add Selenium tests for redirect behavior

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689dfbb080088324a56a861f581caeb1