### PR TITLE
Add teacher portal for site settings and classroom management

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     "goals",
     "reflections",
     "exports",
+    "teacher_portal",
 ]
 
 MIDDLEWARE = [

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -41,4 +41,5 @@ urlpatterns = [
     path("api/", include("goals.urls")),
     path("api/", include("reflections.urls")),
     path("api/", include("exports.urls")),
+    path("teacher/", include("teacher_portal.urls")),
 ]

--- a/src/teacher_portal/apps.py
+++ b/src/teacher_portal/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class TeacherPortalConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "teacher_portal"

--- a/src/teacher_portal/forms.py
+++ b/src/teacher_portal/forms.py
@@ -1,0 +1,19 @@
+from django import forms
+
+from config.models import SiteSettings
+from lessons.models import Classroom
+
+
+class SiteSettingsForm(forms.ModelForm):
+    class Meta:
+        model = SiteSettings
+        fields = ["openai_api_key", "allow_ai"]
+        widgets = {
+            "openai_api_key": forms.PasswordInput(render_value=True),
+        }
+
+
+class ClassroomForm(forms.ModelForm):
+    class Meta:
+        model = Classroom
+        fields = ["name", "code", "use_ai"]

--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}Teacher Portal{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl mb-4">Teacher Portal</h1>
+
+<div class="mb-8">
+    <h2 class="text-xl mb-2">Site Settings</h2>
+    <form method="post">
+        {% csrf_token %}
+        {{ settings_form.as_p }}
+        <button type="submit" name="save_settings" class="bg-blue-500 text-white px-4 py-2">Save</button>
+    </form>
+</div>
+
+<div>
+    <h2 class="text-xl mb-2">Classrooms</h2>
+    <form method="post" class="mb-4">
+        {% csrf_token %}
+        {{ classroom_form.as_p }}
+        <button type="submit" name="add_classroom" class="bg-green-500 text-white px-4 py-2">Add Classroom</button>
+    </form>
+    <ul>
+        {% for c in classrooms %}
+        <li>{{ c.name }}{% if c.use_ai %} (AI){% endif %}</li>
+        {% empty %}
+        <li>No classrooms yet.</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}

--- a/src/teacher_portal/urls.py
+++ b/src/teacher_portal/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+app_name = "teacher_portal"
+
+urlpatterns = [
+    path("", views.portal, name="portal"),
+]

--- a/src/teacher_portal/views.py
+++ b/src/teacher_portal/views.py
@@ -1,0 +1,37 @@
+from django.contrib.admin.views.decorators import staff_member_required
+from django.shortcuts import redirect, render
+
+from config.models import SiteSettings
+from lessons.models import Classroom
+
+from .forms import ClassroomForm, SiteSettingsForm
+
+
+@staff_member_required
+def portal(request):
+    settings_obj = SiteSettings.get()
+    settings_form = SiteSettingsForm(instance=settings_obj)
+    classroom_form = ClassroomForm()
+
+    if request.method == "POST":
+        if "save_settings" in request.POST:
+            settings_form = SiteSettingsForm(request.POST, instance=settings_obj)
+            if settings_form.is_valid():
+                settings_form.save()
+                return redirect("teacher_portal:portal")
+        elif "add_classroom" in request.POST:
+            classroom_form = ClassroomForm(request.POST)
+            if classroom_form.is_valid():
+                classroom_form.save()
+                return redirect("teacher_portal:portal")
+
+    classrooms = Classroom.objects.all()
+    return render(
+        request,
+        "teacher_portal/portal.html",
+        {
+            "settings_form": settings_form,
+            "classroom_form": classroom_form,
+            "classrooms": classrooms,
+        },
+    )

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,9 @@
     <header class="mb-4">
         <nav class="flex gap-4">
             <a href="{% url 'dashboard' %}">Dashboard</a>
+            {% if request.user.is_staff %}
+            <a href="{% url 'teacher_portal:portal' %}">Teacher Portal</a>
+            {% endif %}
             <a href="{% url 'logout' %}">Logout</a>
         </nav>
     </header>

--- a/tests/test_teacher_portal.py
+++ b/tests/test_teacher_portal.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from accounts.models import User
+
+
+class TeacherPortalTests(TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user("teacher", password="pw", is_staff=True)
+        self.client.force_login(self.staff)
+
+    def test_portal_view(self):
+        url = reverse("teacher_portal:portal")
+        resp = self.client.get(url)
+        assert resp.status_code == 200
+        assert b"Site Settings" in resp.content


### PR DESCRIPTION
## Summary
- add new `teacher_portal` app with staff-only view to edit OpenAI key and create classrooms
- expose portal via `/teacher/` and link from navigation for staff
- include basic tests for portal accessibility

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689e03bdac348324b68048102cf5d6dd