### PR TITLE
Add classroom management and automatic codes

### DIFF
--- a/src/lessons/models.py
+++ b/src/lessons/models.py
@@ -11,6 +11,15 @@ class Classroom(models.Model):
     code = models.CharField(max_length=50, blank=True, null=True, unique=True)
     use_ai = models.BooleanField(default=False)
 
+    def save(self, *args, **kwargs):
+        if not self.code:
+            while True:
+                code = uuid.uuid4().hex[:6]
+                if not self.__class__.objects.filter(code=code).exists():
+                    self.code = code
+                    break
+        super().save(*args, **kwargs)
+
     def __str__(self) -> str:  # pragma: no cover - simple
         return self.name
 

--- a/src/teacher_portal/forms.py
+++ b/src/teacher_portal/forms.py
@@ -16,4 +16,4 @@ class SiteSettingsForm(forms.ModelForm):
 class ClassroomForm(forms.ModelForm):
     class Meta:
         model = Classroom
-        fields = ["name", "code", "use_ai"]
+        fields = ["name", "use_ai"]

--- a/src/teacher_portal/templates/teacher_portal/edit_classroom.html
+++ b/src/teacher_portal/templates/teacher_portal/edit_classroom.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block title %}Edit Classroom{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl mb-4">Edit Classroom</h1>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2">Save</button>
+</form>
+<a href="{% url 'teacher_portal:portal' %}" class="text-blue-500">Back</a>
+{% endblock %}
+

--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -21,12 +21,40 @@
         {{ classroom_form.as_p }}
         <button type="submit" name="add_classroom" class="bg-green-500 text-white px-4 py-2">Add Classroom</button>
     </form>
-    <ul>
-        {% for c in classrooms %}
-        <li>{{ c.name }}{% if c.use_ai %} (AI){% endif %}</li>
-        {% empty %}
-        <li>No classrooms yet.</li>
-        {% endfor %}
-    </ul>
+    <table class="min-w-full">
+        <thead>
+            <tr>
+                <th class="text-left">Name</th>
+                <th class="text-left">Code</th>
+                <th class="text-left">AI</th>
+                <th class="text-left">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for c in classrooms %}
+            <tr>
+                <td>{{ c.name }}</td>
+                <td>
+                    <span>{{ c.code }}</span>
+                    <button type="button" onclick="navigator.clipboard.writeText('{{ c.code }}')" class="bg-gray-200 px-2 py-1 ml-2">Copy</button>
+                    <form method="post" action="{% url 'teacher_portal:regenerate_classroom_code' c.id %}" class="inline">
+                        {% csrf_token %}
+                        <button type="submit" class="bg-yellow-500 text-white px-2 py-1 ml-2">Regenerate</button>
+                    </form>
+                </td>
+                <td>{% if c.use_ai %}Yes{% else %}No{% endif %}</td>
+                <td>
+                    <a href="{% url 'teacher_portal:edit_classroom' c.id %}" class="bg-blue-500 text-white px-2 py-1 mr-2">Edit</a>
+                    <form method="post" action="{% url 'teacher_portal:delete_classroom' c.id %}" class="inline">
+                        {% csrf_token %}
+                        <button type="submit" class="bg-red-500 text-white px-2 py-1">Delete</button>
+                    </form>
+                </td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="4">No classrooms yet.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </div>
 {% endblock %}

--- a/src/teacher_portal/urls.py
+++ b/src/teacher_portal/urls.py
@@ -6,4 +6,11 @@ app_name = "teacher_portal"
 
 urlpatterns = [
     path("", views.portal, name="portal"),
+    path("classroom/<uuid:pk>/edit/", views.edit_classroom, name="edit_classroom"),
+    path("classroom/<uuid:pk>/delete/", views.delete_classroom, name="delete_classroom"),
+    path(
+        "classroom/<uuid:pk>/regenerate/",
+        views.regenerate_classroom_code,
+        name="regenerate_classroom_code",
+    ),
 ]

--- a/src/teacher_portal/views.py
+++ b/src/teacher_portal/views.py
@@ -1,5 +1,5 @@
 from django.contrib.admin.views.decorators import staff_member_required
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 
 from config.models import SiteSettings
 from lessons.models import Classroom
@@ -35,3 +35,37 @@ def portal(request):
             "classrooms": classrooms,
         },
     )
+
+
+@staff_member_required
+def edit_classroom(request, pk):
+    classroom = get_object_or_404(Classroom, pk=pk)
+    if request.method == "POST":
+        form = ClassroomForm(request.POST, instance=classroom)
+        if form.is_valid():
+            form.save()
+            return redirect("teacher_portal:portal")
+    else:
+        form = ClassroomForm(instance=classroom)
+    return render(
+        request,
+        "teacher_portal/edit_classroom.html",
+        {"form": form, "classroom": classroom},
+    )
+
+
+@staff_member_required
+def delete_classroom(request, pk):
+    classroom = get_object_or_404(Classroom, pk=pk)
+    if request.method == "POST":
+        classroom.delete()
+    return redirect("teacher_portal:portal")
+
+
+@staff_member_required
+def regenerate_classroom_code(request, pk):
+    classroom = get_object_or_404(Classroom, pk=pk)
+    if request.method == "POST":
+        classroom.code = None
+        classroom.save()
+    return redirect("teacher_portal:portal")


### PR DESCRIPTION
## Summary
- Generate unique classroom codes automatically and allow regeneration
- Add views/routes to edit and delete classrooms
- Show classroom table with copy-to-clipboard codes and action buttons

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689e0b6bcbc48324baa797be30bf5b26