### PR TITLE
Add bulk student management to teacher portal

### DIFF
--- a/src/teacher_portal/forms.py
+++ b/src/teacher_portal/forms.py
@@ -1,5 +1,9 @@
+import csv
+import io
+
 from django import forms
 
+from accounts.models import User
 from config.models import SiteSettings
 from lessons.models import Classroom
 
@@ -17,3 +21,49 @@ class ClassroomForm(forms.ModelForm):
     class Meta:
         model = Classroom
         fields = ["name", "use_ai"]
+
+
+class StudentForm(forms.ModelForm):
+    class Meta:
+        model = User
+        fields = ["pseudonym", "gruppe"]
+
+
+class BulkStudentsForm(forms.Form):
+    gruppe = forms.ChoiceField(choices=User.GROUP_CHOICES)
+    pseudonyms = forms.CharField(
+        widget=forms.Textarea,
+        required=False,
+        help_text="One pseudonym per line.",
+    )
+    csv_file = forms.FileField(required=False)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        pseudonyms_text = cleaned_data.get("pseudonyms", "")
+        csv_file = cleaned_data.get("csv_file")
+        pseudonym_list: list[str] = []
+
+        if pseudonyms_text:
+            pseudonym_list.extend(
+                [p.strip() for p in pseudonyms_text.splitlines() if p.strip()]
+            )
+
+        if csv_file:
+            try:
+                data = csv_file.read().decode("utf-8")
+            except AttributeError:
+                data = csv_file.read().decode()
+            reader = csv.reader(io.StringIO(data))
+            for row in reader:
+                for field in row:
+                    if field.strip():
+                        pseudonym_list.append(field.strip())
+
+        if not pseudonym_list:
+            raise forms.ValidationError(
+                "Please provide pseudonyms via textarea or CSV file."
+            )
+
+        cleaned_data["pseudonym_list"] = pseudonym_list
+        return cleaned_data

--- a/src/teacher_portal/templates/teacher_portal/classroom_students.html
+++ b/src/teacher_portal/templates/teacher_portal/classroom_students.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+
+{% block title %}Students{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl mb-4">Students for {{ classroom.name }}</h1>
+
+<h2 class="text-xl mb-2">Add Students</h2>
+<form method="post" enctype="multipart/form-data" class="mb-4">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="bg-green-500 text-white px-4 py-2">Add Students</button>
+</form>
+
+<h2 class="text-xl mb-2">Student List</h2>
+<table class="min-w-full">
+    <thead>
+        <tr>
+            <th class="text-left">Pseudonym</th>
+            <th class="text-left">Group</th>
+            <th class="text-left">Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for student in students %}
+        <tr>
+            <td>{{ student.pseudonym }}</td>
+            <td>{{ student.get_gruppe_display }}</td>
+            <td>
+                <a href="{% url 'teacher_portal:edit_student' student.id %}" class="bg-blue-500 text-white px-2 py-1 mr-2">Edit</a>
+                <form method="post" action="{% url 'teacher_portal:delete_student' student.id %}" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="bg-red-500 text-white px-2 py-1">Delete</button>
+                </form>
+            </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3">No students yet.</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+<a href="{% url 'teacher_portal:portal' %}" class="text-blue-500">Back</a>
+{% endblock %}

--- a/src/teacher_portal/templates/teacher_portal/edit_student.html
+++ b/src/teacher_portal/templates/teacher_portal/edit_student.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}Edit Student{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl mb-4">Edit Student</h1>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2">Save</button>
+</form>
+<a href="{% url 'teacher_portal:classroom_students' student.classroom.id %}" class="text-blue-500">Back</a>
+{% endblock %}

--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -44,6 +44,7 @@
                 </td>
                 <td>{% if c.use_ai %}Yes{% else %}No{% endif %}</td>
                 <td>
+                    <a href="{% url 'teacher_portal:classroom_students' c.id %}" class="bg-green-500 text-white px-2 py-1 mr-2">Students</a>
                     <a href="{% url 'teacher_portal:edit_classroom' c.id %}" class="bg-blue-500 text-white px-2 py-1 mr-2">Edit</a>
                     <form method="post" action="{% url 'teacher_portal:delete_classroom' c.id %}" class="inline">
                         {% csrf_token %}

--- a/src/teacher_portal/urls.py
+++ b/src/teacher_portal/urls.py
@@ -13,4 +13,11 @@ urlpatterns = [
         views.regenerate_classroom_code,
         name="regenerate_classroom_code",
     ),
+    path(
+        "classroom/<uuid:pk>/students/",
+        views.classroom_students,
+        name="classroom_students",
+    ),
+    path("student/<uuid:pk>/edit/", views.edit_student, name="edit_student"),
+    path("student/<uuid:pk>/delete/", views.delete_student, name="delete_student"),
 ]

--- a/tests/test_teacher_portal.py
+++ b/tests/test_teacher_portal.py
@@ -1,7 +1,9 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import reverse
 
 from accounts.models import User
+from lessons.models import Classroom
 
 
 class TeacherPortalTests(TestCase):
@@ -14,3 +16,28 @@ class TeacherPortalTests(TestCase):
         resp = self.client.get(url)
         assert resp.status_code == 200
         assert b"Site Settings" in resp.content
+
+    def test_bulk_add_students_textarea(self):
+        classroom = Classroom.objects.create(name="Class 1")
+        url = reverse("teacher_portal:classroom_students", args=[classroom.pk])
+        data = {"pseudonyms": "alpha\nbeta", "gruppe": User.VG}
+        resp = self.client.post(url, data)
+        assert resp.status_code == 302
+        students = User.objects.filter(classroom=classroom)
+        assert students.count() == 2
+        assert {s.pseudonym for s in students} == {"alpha", "beta"}
+        assert all(s.gruppe == User.VG for s in students)
+
+    def test_bulk_add_students_csv(self):
+        classroom = Classroom.objects.create(name="Class 1")
+        url = reverse("teacher_portal:classroom_students", args=[classroom.pk])
+        csv_content = "gamma\ndelta"
+        uploaded = SimpleUploadedFile(
+            "students.csv", csv_content.encode("utf-8"), content_type="text/csv"
+        )
+        resp = self.client.post(url, {"gruppe": User.KG, "csv_file": uploaded})
+        assert resp.status_code == 302
+        students = User.objects.filter(classroom=classroom)
+        assert students.count() == 2
+        assert {s.pseudonym for s in students} == {"gamma", "delta"}
+        assert all(s.gruppe == User.KG for s in students)


### PR DESCRIPTION
## Summary
- Allow teachers to bulk add students via textarea or CSV upload and assign group
- Provide student list view with edit/delete actions per classroom
- Test bulk creation and classroom/group assignments

## Testing
- `python manage.py test >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_689e0e48e3388324bc0f526337f6de6e