### PR TITLE
Validate OpenAI API key in site settings

### DIFF
--- a/src/teacher_portal/forms.py
+++ b/src/teacher_portal/forms.py
@@ -1,6 +1,8 @@
 import csv
 import io
 
+import openai
+from openai import OpenAIError
 from django import forms
 
 from accounts.models import User
@@ -15,6 +17,16 @@ class SiteSettingsForm(forms.ModelForm):
         widgets = {
             "openai_api_key": forms.PasswordInput(render_value=True),
         }
+
+    def clean_openai_api_key(self):
+        key = self.cleaned_data.get("openai_api_key")
+        if not key:
+            return key
+        try:
+            openai.OpenAI(api_key=key).models.list()
+        except OpenAIError as exc:
+            raise forms.ValidationError("Invalid OpenAI API key") from exc
+        return key
 
 
 class ClassroomForm(forms.ModelForm):

--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -9,8 +9,29 @@
     <h2 class="text-xl mb-2">Site Settings</h2>
     <form method="post">
         {% csrf_token %}
-        {{ settings_form.as_p }}
-        <button type="submit" name="save_settings" class="bg-blue-500 text-white px-4 py-2">Save</button>
+        <div x-data="{msg: '', ok: null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200; msg = ok ? 'API key valid' : 'API key invalid'" class="space-y-2">
+            <div>
+                {{ settings_form.allow_ai.label_tag }} {{ settings_form.allow_ai }}
+                {% if settings_form.allow_ai.errors %}
+                    <p class="text-red-500">{{ settings_form.allow_ai.errors.0 }}</p>
+                {% endif %}
+            </div>
+            <div>
+                {{ settings_form.openai_api_key.label_tag }}
+                <div class="flex items-center gap-2">
+                    {{ settings_form.openai_api_key }}
+                    <button type="button" class="bg-gray-500 text-white px-2 py-1"
+                            hx-post="{% url 'teacher_portal:check_openai_key' %}"
+                            hx-include="[name='openai_api_key']"
+                            hx-swap="none">Test</button>
+                    <span x-show="msg" x-text="msg" :class="ok ? 'text-green-600' : 'text-red-600'"></span>
+                </div>
+                {% if settings_form.openai_api_key.errors %}
+                    <p class="text-red-500">{{ settings_form.openai_api_key.errors.0 }}</p>
+                {% endif %}
+            </div>
+        </div>
+        <button type="submit" name="save_settings" class="bg-blue-500 text-white px-4 py-2 mt-2">Save</button>
     </form>
 </div>
 

--- a/src/teacher_portal/urls.py
+++ b/src/teacher_portal/urls.py
@@ -6,6 +6,7 @@ app_name = "teacher_portal"
 
 urlpatterns = [
     path("", views.portal, name="portal"),
+    path("validate-key/", views.check_openai_key, name="check_openai_key"),
     path("classroom/<uuid:pk>/edit/", views.edit_classroom, name="edit_classroom"),
     path("classroom/<uuid:pk>/delete/", views.delete_classroom, name="delete_classroom"),
     path(

--- a/src/teacher_portal/views.py
+++ b/src/teacher_portal/views.py
@@ -1,4 +1,5 @@
 from django.contrib.admin.views.decorators import staff_member_required
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 
 from accounts.models import User
@@ -41,6 +42,14 @@ def portal(request):
             "classrooms": classrooms,
         },
     )
+
+
+@staff_member_required
+def check_openai_key(request):
+    form = SiteSettingsForm(request.POST)
+    if form.is_valid():
+        return HttpResponse("OK")
+    return HttpResponse("Invalid", status=400)
 
 
 @staff_member_required


### PR DESCRIPTION
## Summary
- verify OpenAI API key in `SiteSettingsForm` by calling `openai.models.list`
- add HTMX/Alpine UI in teacher portal to test key and show result
- include unit test mocking OpenAI client for invalid keys

## Testing
- `PYTHONPATH=src DJANGO_SETTINGS_MODULE=config.settings pytest tests/test_site_settings.py::SiteSettingsFormTests::test_invalid_openai_key -vv`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_689e102025d483249e44cf2f21371c88