### PR TITLE
Add data export and analytics tabs to teacher portal

### DIFF
--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -4,72 +4,94 @@
 
 {% block content %}
 <h1 class="text-2xl mb-4">Teacher Portal</h1>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
-<div class="grid gap-6">
-    <div class="bg-white p-4 rounded shadow">
-        <h2 class="text-xl mb-2">Site Settings</h2>
-        <form method="post" x-data="{saved:false}" @submit.prevent="$el.submit(); saved=true; setTimeout(()=>saved=false,2000)">
-            {% csrf_token %}
-            <div x-data="{msg: '', ok: null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200; msg = ok ? 'API key valid' : 'API key invalid'" class="space-y-2">
-                <div>
-                    {{ settings_form.allow_ai.label_tag }} {{ settings_form.allow_ai }}
-                    {% if settings_form.allow_ai.errors %}
-                        <p class="text-red-500">{{ settings_form.allow_ai.errors.0 }}</p>
-                    {% endif %}
-                </div>
-                <div>
-                    {{ settings_form.openai_api_key.label_tag }}
-                    <div class="flex items-center gap-2">
-                        {{ settings_form.openai_api_key }}
-                        <button type="button" class="bg-gray-500 text-white px-2 py-1"
-                                hx-post="{% url 'teacher_portal:check_openai_key' %}"
-                                hx-include="[name='openai_api_key']"
-                                hx-swap="none">Test</button>
-                        <span x-show="msg" x-text="msg" x-transition :class="ok ? 'text-green-600' : 'text-red-600'"></span>
+<div x-data="{tab: 'settings'}">
+    <nav class="mb-4 flex gap-4 border-b">
+        <button @click="tab='settings'" :class="{'font-bold border-b-2': tab==='settings'}">Einstellungen</button>
+        <button @click="tab='export'" :class="{'font-bold border-b-2': tab==='export'}">Datenexport</button>
+        <button @click="tab='analysis'" :class="{'font-bold border-b-2': tab==='analysis'}">Auswertung</button>
+    </nav>
+
+    <div x-show="tab==='settings'" class="grid gap-6">
+        <div class="bg-white p-4 rounded shadow">
+            <h2 class="text-xl mb-2">Site Settings</h2>
+            <form method="post" x-data="{saved:false}" @submit.prevent="$el.submit(); saved=true; setTimeout(()=>saved=false,2000)">
+                {% csrf_token %}
+                <div x-data="{msg: '', ok: null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200; msg = ok ? 'API key valid' : 'API key invalid'" class="space-y-2">
+                    <div>
+                        {{ settings_form.allow_ai.label_tag }} {{ settings_form.allow_ai }}
+                        {% if settings_form.allow_ai.errors %}
+                            <p class="text-red-500">{{ settings_form.allow_ai.errors.0 }}</p>
+                        {% endif %}
                     </div>
-                    {% if settings_form.openai_api_key.errors %}
-                        <p class="text-red-500">{{ settings_form.openai_api_key.errors.0 }}</p>
-                    {% endif %}
+                    <div>
+                        {{ settings_form.openai_api_key.label_tag }}
+                        <div class="flex items-center gap-2">
+                            {{ settings_form.openai_api_key }}
+                            <button type="button" class="bg-gray-500 text-white px-2 py-1"
+                                    hx-post="{% url 'teacher_portal:check_openai_key' %}"
+                                    hx-include="[name='openai_api_key']"
+                                    hx-swap="none">Test</button>
+                            <span x-show="msg" x-text="msg" x-transition :class="ok ? 'text-green-600' : 'text-red-600'"></span>
+                        </div>
+                        {% if settings_form.openai_api_key.errors %}
+                            <p class="text-red-500">{{ settings_form.openai_api_key.errors.0 }}</p>
+                        {% endif %}
+                    </div>
                 </div>
+                <p x-show="saved" x-transition class="text-green-600">Gespeichert</p>
+                <button type="submit" name="save_settings" class="bg-blue-500 text-white px-4 py-2 mt-2 rounded transition hover:bg-blue-600">Save</button>
+            </form>
+        </div>
+
+        <div class="bg-white p-4 rounded shadow">
+            <h2 class="text-xl mb-2">Classrooms</h2>
+            <form method="post" class="mb-4" x-data="{added:false}" @submit.prevent="$el.submit(); added=true; setTimeout(()=>added=false,2000)">
+                {% csrf_token %}
+                {{ classroom_form.as_p }}
+                <p x-show="added" x-transition class="text-green-600">Classroom added</p>
+                <button type="submit" name="add_classroom" class="bg-green-500 text-white px-4 py-2 rounded transition hover:bg-green-600">Add Classroom</button>
+            </form>
+            <div class="grid gap-4 md:grid-cols-2">
+                {% for c in classrooms %}
+                <div class="p-4 border rounded shadow transition hover:shadow-lg">
+                    <div class="font-semibold mb-2">{{ c.name }}</div>
+                    <div class="text-sm mb-2">Code: <span>{{ c.code }}</span>
+                        <button type="button" onclick="navigator.clipboard.writeText('{{ c.code }}')" class="bg-gray-200 px-2 py-1 ml-2 rounded">Copy</button>
+                        <form method="post" action="{% url 'teacher_portal:regenerate_classroom_code' c.id %}" class="inline">
+                            {% csrf_token %}
+                            <button type="submit" class="bg-yellow-500 text-white px-2 py-1 ml-2 rounded">Regenerate</button>
+                        </form>
+                    </div>
+                    <div class="text-sm mb-2">AI: {% if c.use_ai %}Yes{% else %}No{% endif %}</div>
+                    <div class="flex flex-wrap gap-2 text-sm">
+                        <a href="{% url 'teacher_portal:classroom_students' c.id %}" class="bg-green-500 text-white px-2 py-1 rounded">Students</a>
+                        <a href="{% url 'teacher_portal:edit_classroom' c.id %}" class="bg-blue-500 text-white px-2 py-1 rounded">Edit</a>
+                        <form method="post" action="{% url 'teacher_portal:delete_classroom' c.id %}" class="inline">
+                            {% csrf_token %}
+                            <button type="submit" class="bg-red-500 text-white px-2 py-1 rounded">Delete</button>
+                        </form>
+                    </div>
+                </div>
+                {% empty %}
+                <p>No classrooms yet.</p>
+                {% endfor %}
             </div>
-            <p x-show="saved" x-transition class="text-green-600">Gespeichert</p>
-            <button type="submit" name="save_settings" class="bg-blue-500 text-white px-4 py-2 mt-2 rounded transition hover:bg-blue-600">Save</button>
-        </form>
+        </div>
     </div>
 
-    <div class="bg-white p-4 rounded shadow">
-        <h2 class="text-xl mb-2">Classrooms</h2>
-        <form method="post" class="mb-4" x-data="{added:false}" @submit.prevent="$el.submit(); added=true; setTimeout(()=>added=false,2000)">
-            {% csrf_token %}
-            {{ classroom_form.as_p }}
-            <p x-show="added" x-transition class="text-green-600">Classroom added</p>
-            <button type="submit" name="add_classroom" class="bg-green-500 text-white px-4 py-2 rounded transition hover:bg-green-600">Add Classroom</button>
-        </form>
-        <div class="grid gap-4 md:grid-cols-2">
-            {% for c in classrooms %}
-            <div class="p-4 border rounded shadow transition hover:shadow-lg">
-                <div class="font-semibold mb-2">{{ c.name }}</div>
-                <div class="text-sm mb-2">Code: <span>{{ c.code }}</span>
-                    <button type="button" onclick="navigator.clipboard.writeText('{{ c.code }}')" class="bg-gray-200 px-2 py-1 ml-2 rounded">Copy</button>
-                    <form method="post" action="{% url 'teacher_portal:regenerate_classroom_code' c.id %}" class="inline">
-                        {% csrf_token %}
-                        <button type="submit" class="bg-yellow-500 text-white px-2 py-1 ml-2 rounded">Regenerate</button>
-                    </form>
-                </div>
-                <div class="text-sm mb-2">AI: {% if c.use_ai %}Yes{% else %}No{% endif %}</div>
-                <div class="flex flex-wrap gap-2 text-sm">
-                    <a href="{% url 'teacher_portal:classroom_students' c.id %}" class="bg-green-500 text-white px-2 py-1 rounded">Students</a>
-                    <a href="{% url 'teacher_portal:edit_classroom' c.id %}" class="bg-blue-500 text-white px-2 py-1 rounded">Edit</a>
-                    <form method="post" action="{% url 'teacher_portal:delete_classroom' c.id %}" class="inline">
-                        {% csrf_token %}
-                        <button type="submit" class="bg-red-500 text-white px-2 py-1 rounded">Delete</button>
-                    </form>
-                </div>
-            </div>
-            {% empty %}
-            <p>No classrooms yet.</p>
-            {% endfor %}
-        </div>
+    <div x-show="tab==='export'" class="bg-white p-4 rounded shadow">
+        <h2 class="text-xl mb-2">Datenexport</h2>
+        <p class="mb-2">CSV herunterladen:</p>
+        <button class="bg-blue-500 text-white px-4 py-2 rounded" onclick="document.getElementById('export-frame').src='/api/export/csv/';">Export CSV</button>
+        <iframe id="export-frame" class="hidden"></iframe>
+    </div>
+
+    <div x-show="tab==='analysis'" class="bg-white p-4 rounded shadow" x-init="fetch('/api/export/dashboard-data/').then(r=>r.json()).then(d=>{ new Chart($refs.group,{type:'bar',data:{labels:d.group_labels,datasets:[{label:'Goals',data:d.group_data}]}}); new Chart($refs.ki,{type:'pie',data:{labels:d.ki_labels,datasets:[{data:d.ki_data}]}}); })">
+        <h2 class="text-xl mb-4">Auswertung</h2>
+        <canvas x-ref="group" class="mb-4"></canvas>
+        <canvas x-ref="ki"></canvas>
     </div>
 </div>
 {% endblock %}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -64,3 +64,12 @@ class ExportViewTests(TestCase):
         ws_goals = wb["OverallGoals"]
         og_headers = [cell.value for cell in next(ws_goals.iter_rows(max_row=1))]
         self.assertIn("exported_at", og_headers)
+
+    def test_csv_requires_staff(self):
+        resp = self.client.get("/api/export/csv/")
+        self.assertEqual(resp.status_code, 200)
+        self.client.logout()
+        User = get_user_model()
+        self.client.force_login(User.objects.create_user(pseudonym="u3", password="pw", is_staff=False))
+        resp = self.client.get("/api/export/csv/")
+        self.assertEqual(resp.status_code, 302)

--- a/tests/test_teacher_portal.py
+++ b/tests/test_teacher_portal.py
@@ -16,6 +16,8 @@ class TeacherPortalTests(TestCase):
         resp = self.client.get(url)
         assert resp.status_code == 200
         assert b"Site Settings" in resp.content
+        assert b"Datenexport" in resp.content
+        assert b"Auswertung" in resp.content
 
     def test_bulk_add_students_textarea(self):
         classroom = Classroom.objects.create(name="Class 1")
@@ -41,3 +43,11 @@ class TeacherPortalTests(TestCase):
         assert students.count() == 2
         assert {s.pseudonym for s in students} == {"gamma", "delta"}
         assert all(s.gruppe == User.KG for s in students)
+
+    def test_portal_requires_staff(self):
+        self.client.logout()
+        student = User.objects.create_user("student", password="pw", is_staff=False)
+        self.client.force_login(student)
+        url = reverse("teacher_portal:portal")
+        resp = self.client.get(url)
+        assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- add tabbed navigation in teacher portal for settings, data export, and analysis
- integrate existing export and dashboard data views; render charts with Chart.js
- restrict access and tests ensuring only staff can reach export endpoints and portal

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689e141438988324ba7a86419613f4d6