### PR TITLE
style: modernize templates with tailwind

### DIFF
--- a/src/config/templatetags/form_tags.py
+++ b/src/config/templatetags/form_tags.py
@@ -1,0 +1,7 @@
+from django import template
+
+register = template.Library()
+
+@register.filter(name="add_class")
+def add_class(field, css):
+    return field.as_widget(attrs={"class": (field.field.widget.attrs.get("class", "") + " " + css).strip()})

--- a/src/teacher_portal/templates/teacher_portal/classroom_students.html
+++ b/src/teacher_portal/templates/teacher_portal/classroom_students.html
@@ -1,44 +1,55 @@
 {% extends "base.html" %}
-
+{% load form_tags %}
 {% block title %}Students{% endblock %}
-
 {% block content %}
-<h1 class="text-2xl mb-4">Students for {{ classroom.name }}</h1>
-
-<h2 class="text-xl mb-2">Add Students</h2>
-<form method="post" enctype="multipart/form-data" class="mb-4">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="bg-green-500 text-white px-4 py-2">Add Students</button>
-</form>
-
-<h2 class="text-xl mb-2">Student List</h2>
-<table class="min-w-full">
-    <thead>
-        <tr>
-            <th class="text-left">Pseudonym</th>
-            <th class="text-left">Group</th>
-            <th class="text-left">Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for student in students %}
-        <tr>
-            <td>{{ student.pseudonym }}</td>
-            <td>{{ student.get_gruppe_display }}</td>
-            <td>
-                <a href="{% url 'teacher_portal:edit_student' student.id %}" class="bg-blue-500 text-white px-2 py-1 mr-2">Edit</a>
-                <form method="post" action="{% url 'teacher_portal:delete_student' student.id %}" class="inline">
-                    {% csrf_token %}
-                    <button type="submit" class="bg-red-500 text-white px-2 py-1">Delete</button>
-                </form>
-            </td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="3">No students yet.</td></tr>
+<h1 class="text-2xl md:text-3xl font-semibold tracking-tight mb-6">Students for {{ classroom.name }}</h1>
+<section class="card mb-6">
+    <h2 class="text-lg md:text-xl font-semibold mb-3">Add Students</h2>
+    <form method="post" enctype="multipart/form-data" class="grid gap-4 md:gap-5">
+        {% csrf_token %}
+        {% for field in form %}
+        <label class="grid gap-1">
+            <span class="text-sm font-medium">{{ field.label }}</span>
+            {{ field|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
+            {% if field.help_text %}<span class="text-xs text-gray-500">{{ field.help_text }}</span>{% endif %}
+            {% for error in field.errors %}<span class="text-xs text-red-600">{{ error }}</span>{% endfor %}
+        </label>
         {% endfor %}
-    </tbody>
-</table>
-
-<a href="{% url 'teacher_portal:portal' %}" class="text-blue-500">Back</a>
+        <div class="flex gap-3">
+            <button type="submit" class="btn-primary">Add Students</button>
+        </div>
+    </form>
+</section>
+<section class="card">
+    <h2 class="text-lg md:text-xl font-semibold mb-3">Student List</h2>
+    <div class="overflow-x-auto rounded-2xl ring-1 ring-gray-200/60 dark:ring-white/10">
+        <table class="w-full text-left text-sm">
+            <thead class="bg-gray-50 dark:bg-gray-800/60">
+                <tr class="text-gray-600 dark:text-gray-300">
+                    <th class="px-4 py-3 font-medium">Pseudonym</th>
+                    <th class="px-4 py-3 font-medium">Group</th>
+                    <th class="px-4 py-3"></th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+                {% for student in students %}
+                <tr class="hover:bg-gray-50/60 dark:hover:bg-gray-800/40">
+                    <td class="px-4 py-3">{{ student.pseudonym }}</td>
+                    <td class="px-4 py-3">{{ student.get_gruppe_display }}</td>
+                    <td class="px-4 py-3 text-right flex gap-2 justify-end">
+                        <a href="{% url 'teacher_portal:edit_student' student.id %}" class="btn-ghost">Edit</a>
+                        <form method="post" action="{% url 'teacher_portal:delete_student' student.id %}" class="inline">
+                            {% csrf_token %}
+                            <button type="submit" class="btn-ghost text-red-600">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="3" class="px-4 py-10 text-center text-gray-600 dark:text-gray-300">😅 Noch nichts hier.</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+<a href="{% url 'teacher_portal:portal' %}" class="btn-ghost mt-4">Back</a>
 {% endblock %}

--- a/src/teacher_portal/templates/teacher_portal/edit_classroom.html
+++ b/src/teacher_portal/templates/teacher_portal/edit_classroom.html
@@ -1,14 +1,22 @@
 {% extends "base.html" %}
-
+{% load form_tags %}
 {% block title %}Edit Classroom{% endblock %}
-
 {% block content %}
-<h1 class="text-2xl mb-4">Edit Classroom</h1>
-<form method="post">
+<h1 class="text-2xl md:text-3xl font-semibold tracking-tight mb-6">Edit Classroom</h1>
+<form method="post" class="card grid gap-4 md:gap-5">
     {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="bg-blue-500 text-white px-4 py-2">Save</button>
+    {% for field in form %}
+    <label class="grid gap-1">
+        <span class="text-sm font-medium">{{ field.label }}</span>
+        {{ field|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
+        {% if field.help_text %}<span class="text-xs text-gray-500">{{ field.help_text }}</span>{% endif %}
+        {% for error in field.errors %}<span class="text-xs text-red-600">{{ error }}</span>{% endfor %}
+    </label>
+    {% endfor %}
+    {% if form.non_field_errors %}{% for error in form.non_field_errors %}<div class="text-red-600 text-sm">{{ error }}</div>{% endfor %}{% endif %}
+    <div class="flex gap-3">
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="{% url 'teacher_portal:portal' %}" class="btn-ghost">Back</a>
+    </div>
 </form>
-<a href="{% url 'teacher_portal:portal' %}" class="text-blue-500">Back</a>
 {% endblock %}
-

--- a/src/teacher_portal/templates/teacher_portal/edit_student.html
+++ b/src/teacher_portal/templates/teacher_portal/edit_student.html
@@ -1,13 +1,21 @@
 {% extends "base.html" %}
-
+{% load form_tags %}
 {% block title %}Edit Student{% endblock %}
-
 {% block content %}
-<h1 class="text-2xl mb-4">Edit Student</h1>
-<form method="post">
+<h1 class="text-2xl md:text-3xl font-semibold tracking-tight mb-6">Edit Student</h1>
+<form method="post" class="card grid gap-4 md:gap-5">
     {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="bg-blue-500 text-white px-4 py-2">Save</button>
+    {% for field in form %}
+    <label class="grid gap-1">
+        <span class="text-sm font-medium">{{ field.label }}</span>
+        {{ field|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
+        {% if field.help_text %}<span class="text-xs text-gray-500">{{ field.help_text }}</span>{% endif %}
+        {% for error in field.errors %}<span class="text-xs text-red-600">{{ error }}</span>{% endfor %}
+    </label>
+    {% endfor %}
+    <div class="flex gap-3">
+        <button type="submit" class="btn-primary">Save</button>
+        <a href="{% url 'teacher_portal:classroom_students' student.classroom.id %}" class="btn-ghost">Back</a>
+    </div>
 </form>
-<a href="{% url 'teacher_portal:classroom_students' student.classroom.id %}" class="text-blue-500">Back</a>
 {% endblock %}

--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -1,95 +1,96 @@
 {% extends "base.html" %}
-
+{% load form_tags %}
 {% block title %}Teacher Portal{% endblock %}
-
 {% block content %}
-<h1 class="text-2xl mb-4">Teacher Portal</h1>
+<h1 class="text-2xl md:text-3xl font-semibold tracking-tight mb-6">Teacher Portal</h1>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-
-<div x-data="{tab: 'settings'}">
-    <nav class="mb-4 flex gap-4 border-b">
-        <button @click="tab='settings'" :class="{'font-bold border-b-2': tab==='settings'}">Einstellungen</button>
-        <button @click="tab='export'" :class="{'font-bold border-b-2': tab==='export'}">Datenexport</button>
-        <button @click="tab='analysis'" :class="{'font-bold border-b-2': tab==='analysis'}">Auswertung</button>
+<div x-data="{tab: 'settings'}" class="grid gap-6">
+    <nav class="flex gap-4 border-b">
+        <button @click="tab='settings'" :class="{'font-bold border-b-2 border-emerald-500': tab==='settings'}" class="px-2 py-2">Einstellungen</button>
+        <button @click="tab='export'" :class="{'font-bold border-b-2 border-emerald-500': tab==='export'}" class="px-2 py-2">Datenexport</button>
+        <button @click="tab='analysis'" :class="{'font-bold border-b-2 border-emerald-500': tab==='analysis'}" class="px-2 py-2">Auswertung</button>
     </nav>
 
     <div x-show="tab==='settings'" class="grid gap-6">
-        <div class="bg-white p-4 rounded shadow">
-            <h2 class="text-xl mb-2">Site Settings</h2>
-            <form method="post" x-data="{saved:false}" @submit.prevent="$el.submit(); saved=true; setTimeout(()=>saved=false,2000)">
+        <section class="card">
+            <h2 class="text-lg md:text-xl font-semibold mb-3">Site Settings</h2>
+            <form method="post" x-data="{saved:false}" @submit.prevent="$el.submit(); saved=true; setTimeout(()=>saved=false,2000)" class="grid gap-4 md:gap-5">
                 {% csrf_token %}
-                <div x-data="{msg: '', ok: null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200; msg = ok ? 'API key valid' : 'API key invalid'" class="space-y-2">
+                <div x-data="{msg: '', ok: null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200; msg = ok ? 'API key valid' : 'API key invalid'" class="grid gap-4 md:gap-5">
                     <div>
                         {{ settings_form.allow_ai.label_tag }} {{ settings_form.allow_ai }}
-                        {% if settings_form.allow_ai.errors %}
-                            <p class="text-red-500">{{ settings_form.allow_ai.errors.0 }}</p>
-                        {% endif %}
+                        {% if settings_form.allow_ai.errors %}<p class="text-red-500 text-sm">{{ settings_form.allow_ai.errors.0 }}</p>{% endif %}
                     </div>
                     <div>
                         {{ settings_form.openai_api_key.label_tag }}
                         <div class="flex items-center gap-2">
-                            {{ settings_form.openai_api_key }}
-                            <button type="button" class="bg-gray-500 text-white px-2 py-1"
+                            {{ settings_form.openai_api_key|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
+                            <button type="button" class="btn-ghost"
                                     hx-post="{% url 'teacher_portal:check_openai_key' %}"
                                     hx-include="[name='openai_api_key']"
                                     hx-swap="none">Test</button>
-                            <span x-show="msg" x-text="msg" x-transition :class="ok ? 'text-green-600' : 'text-red-600'"></span>
+                            <span x-show="msg" x-text="msg" x-transition :class="ok ? 'text-emerald-600' : 'text-red-600'"></span>
                         </div>
-                        {% if settings_form.openai_api_key.errors %}
-                            <p class="text-red-500">{{ settings_form.openai_api_key.errors.0 }}</p>
-                        {% endif %}
+                        {% if settings_form.openai_api_key.errors %}<p class="text-red-500 text-sm">{{ settings_form.openai_api_key.errors.0 }}</p>{% endif %}
                     </div>
                 </div>
-                <p x-show="saved" x-transition class="text-green-600">Gespeichert</p>
-                <button type="submit" name="save_settings" class="bg-blue-500 text-white px-4 py-2 mt-2 rounded transition hover:bg-blue-600">Save</button>
+                <p x-show="saved" x-transition class="text-emerald-600">Gespeichert</p>
+                <button type="submit" name="save_settings" class="btn-primary mt-2">Save</button>
             </form>
-        </div>
+        </section>
 
-        <div class="bg-white p-4 rounded shadow">
-            <h2 class="text-xl mb-2">Classrooms</h2>
-            <form method="post" class="mb-4" x-data="{added:false}" @submit.prevent="$el.submit(); added=true; setTimeout(()=>added=false,2000)">
+        <section class="card">
+            <h2 class="text-lg md:text-xl font-semibold mb-3">Classrooms</h2>
+            <form method="post" class="grid gap-4 md:gap-5 mb-4" x-data="{added:false}" @submit.prevent="$el.submit(); added=true; setTimeout(()=>added=false,2000)">
                 {% csrf_token %}
-                {{ classroom_form.as_p }}
-                <p x-show="added" x-transition class="text-green-600">Classroom added</p>
-                <button type="submit" name="add_classroom" class="bg-green-500 text-white px-4 py-2 rounded transition hover:bg-green-600">Add Classroom</button>
+                {% for field in classroom_form %}
+                <label class="grid gap-1">
+                    <span class="text-sm font-medium">{{ field.label }}</span>
+                    {{ field|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
+                    {% if field.help_text %}<span class="text-xs text-gray-500">{{ field.help_text }}</span>{% endif %}
+                    {% for error in field.errors %}<span class="text-xs text-red-600">{{ error }}</span>{% endfor %}
+                </label>
+                {% endfor %}
+                <p x-show="added" x-transition class="text-emerald-600">Classroom added</p>
+                <button type="submit" name="add_classroom" class="btn-primary">Add Classroom</button>
             </form>
             <div class="grid gap-4 md:grid-cols-2">
                 {% for c in classrooms %}
-                <div class="p-4 border rounded shadow transition hover:shadow-lg">
+                <div class="card">
                     <div class="font-semibold mb-2">{{ c.name }}</div>
                     <div class="text-sm mb-2">Code: <span>{{ c.code }}</span>
-                        <button type="button" onclick="navigator.clipboard.writeText('{{ c.code }}')" class="bg-gray-200 px-2 py-1 ml-2 rounded">Copy</button>
+                        <button type="button" onclick="navigator.clipboard.writeText('{{ c.code }}')" class="btn-ghost ml-2">Copy</button>
                         <form method="post" action="{% url 'teacher_portal:regenerate_classroom_code' c.id %}" class="inline">
                             {% csrf_token %}
-                            <button type="submit" class="bg-yellow-500 text-white px-2 py-1 ml-2 rounded">Regenerate</button>
+                            <button type="submit" class="btn-secondary ml-2">Regenerate</button>
                         </form>
                     </div>
                     <div class="text-sm mb-2">AI: {% if c.use_ai %}Yes{% else %}No{% endif %}</div>
                     <div class="flex flex-wrap gap-2 text-sm">
-                        <a href="{% url 'teacher_portal:classroom_students' c.id %}" class="bg-green-500 text-white px-2 py-1 rounded">Students</a>
-                        <a href="{% url 'teacher_portal:edit_classroom' c.id %}" class="bg-blue-500 text-white px-2 py-1 rounded">Edit</a>
+                        <a href="{% url 'teacher_portal:classroom_students' c.id %}" class="btn-primary">Students</a>
+                        <a href="{% url 'teacher_portal:edit_classroom' c.id %}" class="btn-secondary">Edit</a>
                         <form method="post" action="{% url 'teacher_portal:delete_classroom' c.id %}" class="inline">
                             {% csrf_token %}
-                            <button type="submit" class="bg-red-500 text-white px-2 py-1 rounded">Delete</button>
+                            <button type="submit" class="btn-ghost text-red-600">Delete</button>
                         </form>
                     </div>
                 </div>
                 {% empty %}
-                <p>No classrooms yet.</p>
+                <p>Keine Klassen vorhanden.</p>
                 {% endfor %}
             </div>
-        </div>
+        </section>
     </div>
 
-    <div x-show="tab==='export'" class="bg-white p-4 rounded shadow">
-        <h2 class="text-xl mb-2">Datenexport</h2>
+    <div x-show="tab==='export'" class="card">
+        <h2 class="text-lg md:text-xl font-semibold mb-3">Datenexport</h2>
         <p class="mb-2">CSV herunterladen:</p>
-        <button class="bg-blue-500 text-white px-4 py-2 rounded" onclick="document.getElementById('export-frame').src='/api/export/csv/';">Export CSV</button>
+        <button class="btn-secondary" onclick="document.getElementById('export-frame').src='/api/export/csv/';">Export CSV</button>
         <iframe id="export-frame" class="hidden"></iframe>
     </div>
 
-    <div x-show="tab==='analysis'" class="bg-white p-4 rounded shadow" x-init="fetch('/api/export/dashboard-data/').then(r=>r.json()).then(d=>{ new Chart($refs.group,{type:'bar',data:{labels:d.group_labels,datasets:[{label:'Goals',data:d.group_data}]}}); new Chart($refs.ki,{type:'pie',data:{labels:d.ki_labels,datasets:[{data:d.ki_data}]}}); })">
-        <h2 class="text-xl mb-4">Auswertung</h2>
+    <div x-show="tab==='analysis'" class="card" x-init="fetch('/api/export/dashboard-data/').then(r=>r.json()).then(d=>{ new Chart($refs.group,{type:'bar',data:{labels:d.group_labels,datasets:[{label:'Goals',data:d.group_data}]}}); new Chart($refs.ki,{type:'pie',data:{labels:d.ki_labels,datasets:[{data:d.ki_data}]}}); })">
+        <h2 class="text-lg md:text-xl font-semibold mb-4">Auswertung</h2>
         <canvas x-ref="group" class="mb-4"></canvas>
         <canvas x-ref="ki"></canvas>
     </div>

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -1,0 +1,17 @@
+@layer components {
+  .btn-primary {
+    @apply inline-flex items-center gap-2 rounded-xl bg-emerald-600 text-white px-4 py-2 font-medium shadow-sm hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50;
+  }
+  .btn-secondary {
+    @apply inline-flex items-center gap-2 rounded-xl bg-blue-600 text-white px-4 py-2 font-medium hover:bg-blue-700 focus:ring-2 focus:ring-blue-500;
+  }
+  .btn-ghost {
+    @apply inline-flex items-center gap-2 rounded-xl px-3 py-2 text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400;
+  }
+  .badge {
+    @apply inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300;
+  }
+  .card {
+    @apply bg-white dark:bg-gray-900 rounded-2xl shadow-sm ring-1 ring-gray-200/60 dark:ring-white/10 p-5 md:p-6 hover:shadow-md transition;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,40 +1,24 @@
+{% load static %}
 <!DOCTYPE html>
-<html lang="de">
+<html lang="de" class="h-full" x-data="{}">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>if(localStorage.getItem('dark')==='true'){document.documentElement.classList.add('dark');}</script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="{% static 'css/global.css' %}">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <title>{% block title %}SRL Platform{% endblock %}</title>
 </head>
-<body class="p-4 max-w-xl mx-auto" x-data="{ open: false }">
+<body class="bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 min-h-full">
     {% if request.user.is_authenticated %}
-    <header class="mb-4">
-        <div class="flex items-center justify-between">
-            <a href="{% url 'dashboard' %}" class="text-xl font-semibold">EduNav</a>
-            <button class="md:hidden" @click="open = !open" aria-label="Menu">
-                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-                </svg>
-            </button>
-            <nav class="hidden md:flex gap-4">
-                <a href="{% url 'dashboard' %}" class="hover:underline">Dashboard</a>
-                {% if request.user.is_staff %}
-                <a href="{% url 'teacher_portal:portal' %}" class="hover:underline">Teacher Portal</a>
-                {% endif %}
-                <a href="{% url 'logout' %}" class="hover:underline">Logout</a>
-            </nav>
-        </div>
-        <nav class="flex flex-col gap-2 mt-2 md:hidden" x-show="open" x-transition @click.away="open = false">
-            <a href="{% url 'dashboard' %}" @click="open = false">Dashboard</a>
-            {% if request.user.is_staff %}
-            <a href="{% url 'teacher_portal:portal' %}" @click="open = false">Teacher Portal</a>
-            {% endif %}
-            <a href="{% url 'logout' %}" @click="open = false">Logout</a>
-        </nav>
-    </header>
+        {% include 'includes/nav.html' %}
     {% endif %}
-    {% block content %}{% endblock %}
+    <main class="container mx-auto max-w-6xl px-4 lg:px-6 py-6">
+        {% include 'includes/messages.html' %}
+        {% block content %}{% endblock %}
+    </main>
+    {% include 'includes/footer.html' %}
 </body>
 </html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,74 +1,74 @@
 {% extends 'base.html' %}
 {% block title %}Dashboard{% endblock %}
 {% block content %}
-<h1 class="text-xl mb-4">Hallo {{ user.pseudonym }} ({{ user.gruppe }})</h1>
-<div class="grid gap-4">
+<h1 class="text-2xl md:text-3xl font-semibold tracking-tight mb-6">Hallo {{ user.pseudonym }} ({{ user.gruppe }})</h1>
+<div class="grid gap-4 md:gap-6">
     {% if overall_goal %}
-    <div class="p-4 bg-white rounded shadow">
-        <h2 class="text-lg mb-2">Aktuelles Gesamtziel</h2>
-        <p class="mb-2">{{ overall_goal.text }}</p>
-        <a href="{% url 'overall_goal' %}" class="text-blue-500 underline">Bearbeiten</a>
+    <section class="card">
+        <header class="flex items-center justify-between mb-3">
+            <h2 class="text-lg md:text-xl font-semibold">Aktuelles Gesamtziel</h2>
+            <a href="{% url 'overall_goal' %}" class="btn-ghost">Bearbeiten</a>
+        </header>
+        <p class="text-gray-600 dark:text-gray-300">{{ overall_goal.text }}</p>
         <canvas id="progressChart" class="mt-4"></canvas>
         <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
         <script>
         const completed = {{ completed_goals }};
         const open = {{ open_goals }};
-        new Chart(document.getElementById('progressChart'), {
-            type: 'doughnut',
-            data: {
-                labels: ['Erfüllt','Offen'],
-                datasets: [{
-                    data: [completed, open],
-                    backgroundColor: ['#22c55e','#e5e7eb']
-                }]
-            },
-            options: {
-                plugins: { legend: { position: 'bottom' } }
-            }
-        });
+        const ctx = document.getElementById('progressChart');
+        let progressChart;
+        function drawChart(){
+            const dark = document.documentElement.classList.contains('dark');
+            const openColor = dark ? '#334155' : '#e5e7eb';
+            progressChart = new Chart(ctx, {
+                type: 'doughnut',
+                data: {
+                    labels: ['Erfüllt','Offen'],
+                    datasets: [{ data: [completed, open], backgroundColor: ['#10b981', openColor] }]
+                },
+                options: {
+                    cutout: '70%',
+                    plugins: { legend: { position: 'bottom', labels:{boxWidth:12} } }
+                }
+            });
+        }
+        drawChart();
+        document.addEventListener('toggle-dark', () => { progressChart.destroy(); drawChart(); });
         </script>
-    </div>
+    </section>
     {% else %}
-    <div class="p-4 bg-white rounded shadow">
-        <a href="{% url 'overall_goal' %}" class="text-blue-500 underline">Gesamtziel festlegen</a>
-    </div>
+    <section class="card">
+        <a href="{% url 'overall_goal' %}" class="btn-primary">Gesamtziel festlegen</a>
+    </section>
     {% endif %}
 
-    <div class="grid gap-2 sm:grid-cols-2" id="goal-section">
+    <div class="grid gap-4 md:gap-6" id="goal-section">
         {% if can_use_ai %}
-        <a href="{% url 'goal_vg' %}" class="bg-green-500 text-white px-4 py-2 text-center rounded transition hover:bg-green-600">Ziel setzen</a>
+        <a href="{% url 'goal_vg' %}" class="btn-primary text-center">Ziel setzen</a>
         {% else %}
-        <a href="{% url 'goal_kg' %}" class="bg-green-500 text-white px-4 py-2 text-center rounded transition hover:bg-green-600">Ziel setzen</a>
+        <a href="{% url 'goal_kg' %}" class="btn-primary text-center">Ziel setzen</a>
         {% endif %}
         {% if current_goal %}
-        <a href="{% url 'reflection' %}" class="bg-blue-500 text-white px-4 py-2 text-center rounded transition hover:bg-blue-600">Reflexion starten</a>
+        <a href="{% url 'reflection' %}" class="btn-secondary text-center">Reflexion starten</a>
         {% endif %}
     </div>
 
     {% if goals %}
-    <div>
-        <h2 class="text-lg mb-2">Vergangene Ziele</h2>
-        <div class="grid gap-4 sm:grid-cols-2">
+    <section class="grid gap-4 md:gap-6">
+        <h2 class="text-lg md:text-xl font-semibold">Vergangene Ziele</h2>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
             {% for goal in goals %}
             {% with reflection=goal.reflection_set.first %}
-            <div class="p-4 bg-white rounded shadow text-sm transition hover:shadow-lg">
+            <div class="card text-sm">
                 <div class="font-semibold">{{ goal.final_text|default:goal.raw_text }}</div>
-                <div class="text-gray-600">{{ goal.user_session.lesson_session.date }}</div>
-                <div>SMART:
-                    {% if goal.smart_score %}
-                        {% if goal.smart_score.overall %}
-                            {{ goal.smart_score.overall }}
-                        {% elif goal.smart_score.score %}
-                            {{ goal.smart_score.score }}
-                        {% else %}-{% endif %}
-                    {% else %}-{% endif %}
-                </div>
+                <div class="text-gray-600 dark:text-gray-300">{{ goal.user_session.lesson_session.date }}</div>
+                <div>SMART: {% if goal.smart_score %}{% if goal.smart_score.overall %}{{ goal.smart_score.overall }}{% elif goal.smart_score.score %}{{ goal.smart_score.score }}{% else %}-{% endif %}{% else %}-{% endif %}</div>
                 <div>Reflexion: {% if reflection %}{{ reflection.get_result_display }}{% else %}-{% endif %}</div>
             </div>
             {% endwith %}
             {% endfor %}
         </div>
-    </div>
+    </section>
     {% endif %}
 </div>
 {% endblock %}

--- a/templates/goal_kg.html
+++ b/templates/goal_kg.html
@@ -1,18 +1,24 @@
 {% extends 'base.html' %}
 {% block title %}Zielsetzung KG{% endblock %}
 {% block content %}
-<div x-data="goalKG()" class="space-y-4">
-    <form hx-post="/api/goals/" hx-swap="none" @htmx:afterRequest="updateSmart" class="space-y-2">
+<section x-data="goalKG()" class="grid gap-4 md:gap-6">
+    <form hx-post="/api/goals/" hx-swap="none" @htmx:afterRequest="updateSmart" class="card grid gap-4 md:gap-5">
         <input type="hidden" name="user_session" value="{{ user_session_id }}">
-        <textarea name="raw_text" class="w-full border p-2" placeholder="Was möchtest du erreichen?"></textarea>
-        <button class="bg-green-500 text-white px-4 py-2 w-full sm:w-auto">Ziel speichern</button>
+        <label class="grid gap-1">
+            <span class="text-sm font-medium">Was möchtest du erreichen?</span>
+            <textarea name="raw_text" class="w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"></textarea>
+        </label>
+        <div class="flex gap-3">
+            <button class="btn-primary w-full sm:w-auto" type="submit">Ziel speichern</button>
+            <a href="{% url 'dashboard' %}" class="btn-ghost">Abbrechen</a>
+        </div>
     </form>
     <div class="flex flex-wrap gap-2 text-xs">
         <template x-for="(val, key) in smart" :key="key">
-            <span class="px-2 py-1 rounded" :class="val ? 'bg-green-200' : 'bg-gray-200'" x-text="key"></span>
+            <span class="badge" :class="val ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300' : ''" x-text="key"></span>
         </template>
     </div>
-</div>
+</section>
 <script>
 function goalKG(){
     return {

--- a/templates/goal_vg.html
+++ b/templates/goal_vg.html
@@ -1,22 +1,19 @@
 {% extends 'base.html' %}
 {% block title %}Zielsetzung VG{% endblock %}
 {% block content %}
-<div x-data="goalCoach()" class="space-y-4">
-    <div id="chat" class="space-y-2 border p-2 rounded h-64 overflow-y-auto"></div>
-    <form :hx-post="goalId ? '/api/vg/coach/next/' : '/api/vg/goals/'"
-          hx-swap="none"
-          @htmx:afterRequest="handleResponse"
-          class="flex flex-col sm:flex-row gap-2">
+<div x-data="goalCoach()" class="grid gap-4 md:gap-6">
+    <div id="chat" class="card h-64 overflow-y-auto space-y-2"></div>
+    <form :hx-post="goalId ? '/api/vg/coach/next/' : '/api/vg/goals/'" hx-swap="none" @htmx:afterRequest="handleResponse" class="flex flex-col sm:flex-row gap-2">
         <input type="hidden" name="user_session" value="{{ user_session_id }}" x-show="!goalId">
         <input type="hidden" name="goal_id" :value="goalId" x-show="goalId">
-        <textarea x-model="message" class="flex-1 border p-2" placeholder="Deine Nachricht..."></textarea>
+        <textarea x-model="message" class="flex-1 rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" placeholder="Deine Nachricht..."></textarea>
         <input type="hidden" name="raw_text" :value="message" x-show="!goalId">
         <input type="hidden" name="user_reply" :value="message" x-show="goalId">
-        <button class="bg-blue-500 text-white px-4 py-2 sm:self-start">Senden</button>
+        <button class="btn-secondary sm:self-start" type="submit">Senden</button>
     </form>
     <div class="flex flex-wrap gap-2 text-xs">
         <template x-for="(val, key) in smart" :key="key">
-            <span class="px-2 py-1 rounded" :class="val ? 'bg-green-200' : 'bg-gray-200'" x-text="key"></span>
+            <span class="badge" :class="val ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300' : ''" x-text="key"></span>
         </template>
     </div>
 </div>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -1,0 +1,3 @@
+<footer class="py-6 text-center text-sm text-gray-600 dark:text-gray-400">
+  &copy; {% now "Y" %} EduNav
+</footer>

--- a/templates/includes/messages.html
+++ b/templates/includes/messages.html
@@ -1,0 +1,14 @@
+<div x-data="{show:true}" x-show="show" x-transition class="fixed inset-x-0 top-4 z-50 flex justify-center">
+  {% for message in messages %}
+  <div class="mx-2 rounded-xl px-4 py-3 shadow-lg ring-1 ring-black/5 text-white"
+       :class="{'bg-emerald-600': '{{ message.tags }}'.includes('success'),
+                'bg-blue-600': '{{ message.tags }}'.includes('info'),
+                'bg-yellow-600': '{{ message.tags }}'.includes('warning'),
+                'bg-red-600': '{{ message.tags }}'.includes('error')}">
+    <div class="flex items-center gap-3">
+      <span class="font-medium">{{ message }}</span>
+      <button @click="show=false" class="btn-ghost text-white/90">Schließen</button>
+    </div>
+  </div>
+  {% endfor %}
+</div>

--- a/templates/includes/nav.html
+++ b/templates/includes/nav.html
@@ -1,0 +1,32 @@
+{% url 'dashboard' as dashboard_url %}
+{% if request.user.is_staff %}{% url 'teacher_portal:portal' as portal_url %}{% endif %}
+<header class="sticky top-0 z-40 bg-white/80 dark:bg-gray-900/80 backdrop-blur border-b border-gray-200 dark:border-gray-800" x-data="{open:false,dark:document.documentElement.classList.contains('dark')}">
+  <div class="container mx-auto max-w-6xl px-4 lg:px-6 flex items-center justify-between h-16">
+    <a href="{{ dashboard_url }}" class="text-lg font-semibold">EduNav</a>
+    <nav class="hidden md:flex items-center gap-3">
+      <a href="{{ dashboard_url }}" class="btn-ghost" {% if request.path == dashboard_url %}aria-current="page"{% endif %}>Dashboard</a>
+      {% if request.user.is_staff %}
+      <a href="{{ portal_url }}" class="btn-ghost" {% if request.path == portal_url %}aria-current="page"{% endif %}>Teacher Portal</a>
+      {% endif %}
+      <button @click="dark=!dark;localStorage.setItem('dark',dark);document.documentElement.classList.toggle('dark',dark);document.dispatchEvent(new CustomEvent('toggle-dark'))" class="btn-ghost" :aria-label="dark ? 'Hellmodus' : 'Dunkelmodus'">
+        <svg x-show="!dark" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path d="M10 2a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0v-1.5A.75.75 0 0110 2zM10 14.5a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0v-1.5a.75.75 0 01.75-.75zM4.72 4.72a.75.75 0 011.06 0l1.06 1.06a.75.75 0 11-1.06 1.06L4.72 5.78a.75.75 0 010-1.06zm8.48 8.48a.75.75 0 011.06 0l1.06 1.06a.75.75 0 01-1.06 1.06l-1.06-1.06a.75.75 0 010-1.06zM2 10a.75.75 0 01.75-.75h1.5a.75.75 0 010 1.5h-1.5A.75.75 0 012 10zm14.5 0a.75.75 0 01.75-.75h1.5a.75.75 0 010 1.5h-1.5a.75.75 0 01-.75-.75zM4.72 15.28a.75.75 0 010-1.06l1.06-1.06a.75.75 0 111.06 1.06L5.78 15.28a.75.75 0 01-1.06 0zm8.48-8.48a.75.75 0 010-1.06l1.06-1.06a.75.75 0 111.06 1.06l-1.06 1.06a.75.75 0 01-1.06 0zM10 5.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9z"/></svg>
+        <svg x-show="dark" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M17.293 13.293a8 8 0 01-10.586-10.586 8 8 0 1010.586 10.586z" clip-rule="evenodd"/></svg>
+      </button>
+      <a href="{% url 'logout' %}" class="btn-ghost">Logout</a>
+    </nav>
+    <button class="md:hidden btn-ghost" @click="open=!open" aria-label="Menu">
+      <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+      <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+    </button>
+  </div>
+  <nav class="md:hidden border-t border-gray-200 dark:border-gray-800" x-show="open" x-transition>
+    <div class="container mx-auto max-w-6xl px-4 lg:px-6 py-4 flex flex-col gap-2">
+      <a href="{{ dashboard_url }}" class="btn-ghost" {% if request.path == dashboard_url %}aria-current="page"{% endif %}>Dashboard</a>
+      {% if request.user.is_staff %}
+      <a href="{{ portal_url }}" class="btn-ghost" {% if request.path == portal_url %}aria-current="page"{% endif %}>Teacher Portal</a>
+      {% endif %}
+      <button @click="dark=!dark;localStorage.setItem('dark',dark);document.documentElement.classList.toggle('dark',dark);document.dispatchEvent(new CustomEvent('toggle-dark'))" class="btn-ghost text-left">Dark Mode</button>
+      <a href="{% url 'logout' %}" class="btn-ghost">Logout</a>
+    </div>
+  </nav>
+</header>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,16 +1,24 @@
 {% extends 'base.html' %}
 {% block title %}Login{% endblock %}
 {% block content %}
-<div class="max-w-sm mx-auto bg-white p-6 rounded shadow">
-    <h1 class="text-xl mb-4">Login</h1>
+<section class="card w-full max-w-sm mx-auto">
+    <h1 class="text-2xl md:text-3xl font-semibold tracking-tight mb-4">Login</h1>
     {% if error %}
-    <p x-data="{show:true}" x-show="show" x-transition x-init="setTimeout(()=>show=false,3000)" class="text-red-500 mb-2 animate-pulse">{{ error }}</p>
+    <p x-data="{show:true}" x-show="show" x-transition class="text-red-600 mb-2">{{ error }}</p>
     {% endif %}
-    <form method="post" class="space-y-2">
+    <form method="post" class="grid gap-4 md:gap-5">
         {% csrf_token %}
-        <input type="text" name="pseudonym" placeholder="Pseudonym" class="w-full border p-2" required />
-        <input type="text" name="class_code" placeholder="Klasse" class="w-full border p-2" />
-        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded transition hover:bg-blue-600">Einloggen</button>
+        <label class="grid gap-1">
+            <span class="text-sm font-medium">Pseudonym</span>
+            <input type="text" name="pseudonym" required class="w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" />
+        </label>
+        <label class="grid gap-1">
+            <span class="text-sm font-medium">Klasse</span>
+            <input type="text" name="class_code" class="w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" />
+        </label>
+        <div class="flex gap-3">
+            <button type="submit" class="btn-primary">Einloggen</button>
+        </div>
     </form>
-</div>
+</section>
 {% endblock %}

--- a/templates/overall_goal.html
+++ b/templates/overall_goal.html
@@ -1,9 +1,15 @@
 {% extends 'base.html' %}
 {% block title %}Gesamtziel{% endblock %}
 {% block content %}
-<h1 class="text-xl mb-4">Gesamtziel festlegen</h1>
-<form hx-post="/api/overall-goal/" hx-swap="none" @htmx:afterRequest="window.location.href='{% url 'dashboard' %}'" class="space-y-2">
-    <textarea name="text" class="w-full border p-2" rows="4">{{ goal.text|default:"" }}</textarea>
-    <button type="submit" class="bg-green-500 text-white px-4 py-2">Speichern</button>
+<h1 class="text-2xl md:text-3xl font-semibold tracking-tight mb-6">Gesamtziel festlegen</h1>
+<form hx-post="/api/overall-goal/" hx-swap="none" @htmx:afterRequest="window.location.href='{% url 'dashboard' %}'" class="grid gap-4 md:gap-5">
+    <label class="grid gap-1">
+        <span class="text-sm font-medium">Gesamtziel</span>
+        <textarea name="text" rows="4" class="w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500">{{ goal.text|default:"" }}</textarea>
+    </label>
+    <div class="flex gap-3">
+        <button type="submit" class="btn-primary">Speichern</button>
+        <a href="{% url 'dashboard' %}" class="btn-ghost">Abbrechen</a>
+    </div>
 </form>
 {% endblock %}

--- a/templates/reflection.html
+++ b/templates/reflection.html
@@ -1,46 +1,40 @@
 {% extends 'base.html' %}
 {% block title %}Reflexion{% endblock %}
 {% block content %}
-<div x-data="reflectionForm()" class="space-y-2">
-    <form x-show="!submitted"
-          hx-post="/api/reflections/"
-          hx-swap="none"
-          @htmx:afterRequest="handleResponse"
-          class="space-y-2">
+<section x-data="reflectionForm()" class="grid gap-4 md:gap-6">
+    <form x-show="!submitted" hx-post="/api/reflections/" hx-swap="none" @htmx:afterRequest="handleResponse" class="card grid gap-4 md:gap-5">
         <input type="hidden" name="user_session" value="{{ user_session_id }}">
         <input type="hidden" name="goal" value="{{ goal_id }}">
-        <div class="space-y-1">
-            <p>Hast du dein Ziel erreicht?</p>
-            <label class="block"><input type="radio" name="result" value="yes"> Ja</label>
-            <label class="block"><input type="radio" name="result" value="partial"> Teilweise</label>
-            <label class="block"><input type="radio" name="result" value="no"> Nein</label>
+        <div class="grid gap-2">
+            <p class="text-sm font-medium">Hast du dein Ziel erreicht?</p>
+            <label class="inline-flex items-center gap-2"><input type="radio" name="result" value="yes"> <span>Ja</span></label>
+            <label class="inline-flex items-center gap-2"><input type="radio" name="result" value="partial"> <span>Teilweise</span></label>
+            <label class="inline-flex items-center gap-2"><input type="radio" name="result" value="no"> <span>Nein</span></label>
         </div>
-        <textarea name="obstacles" class="w-full border p-2" placeholder="Welche Hindernisse gab es?"></textarea>
-        <textarea name="next_step" class="w-full border p-2" placeholder="Was ist dein nächster Schritt?"></textarea>
+        <label class="grid gap-1">
+            <span class="text-sm font-medium">Welche Hindernisse gab es?</span>
+            <textarea name="obstacles" class="w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"></textarea>
+        </label>
+        <label class="grid gap-1">
+            <span class="text-sm font-medium">Was ist dein nächster Schritt?</span>
+            <textarea name="next_step" class="w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"></textarea>
+        </label>
         {% if can_use_ai %}
-        <button type="button"
-                class="bg-gray-500 text-white px-4 py-2 w-full sm:w-auto"
-                hx-post="/api/vg/next-step/suggest/"
-                hx-include="closest form"
-                hx-swap="none"
-                @htmx:afterRequest="handleSuggestions">KI-Vorschläge anzeigen</button>
-        <div class="space-y-1" x-show="suggestions.length">
+        <button type="button" class="btn-ghost w-full sm:w-auto" hx-post="/api/vg/next-step/suggest/" hx-include="closest form" hx-swap="none" @htmx:afterRequest="handleSuggestions">KI-Vorschläge anzeigen</button>
+        <div class="grid gap-2" x-show="suggestions.length">
             <template x-for="s in suggestions" :key="s">
-                <button type="button" class="border w-full text-left px-2 py-1"
-                        hx-post="/api/vg/next-step/suggest/"
-                        :hx-vals="{selected: s}"
-                        hx-include="closest form"
-                        hx-swap="none"
-                        @htmx:afterRequest="handleResponse"
-                        x-text="s"></button>
+                <button type="button" class="btn-ghost justify-start" hx-post="/api/vg/next-step/suggest/" :hx-vals="{selected: s}" hx-include="closest form" hx-swap="none" @htmx:afterRequest="handleResponse" x-text="s"></button>
             </template>
         </div>
         {% endif %}
-        <button class="bg-blue-500 text-white px-4 py-2 w-full sm:w-auto">Reflexion speichern</button>
+        <div class="flex gap-3">
+            <button class="btn-secondary w-full sm:w-auto" type="submit">Reflexion speichern</button>
+            <a href="{% url 'dashboard' %}" class="btn-ghost">Abbrechen</a>
+        </div>
     </form>
-    <div x-show="submitted" class="p-4 bg-green-100 rounded">Danke für deine Reflexion!</div>
-    <div x-show="error" class="p-4 bg-red-100 rounded" x-text="error"></div>
-</div>
+    <div x-show="submitted" class="card bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300">Danke für deine Reflexion!</div>
+    <div x-show="error" class="card bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300" x-text="error"></div>
+</section>
 <script>
 function reflectionForm(){
     return {


### PR DESCRIPTION
## Summary
- add global Tailwind component classes and card styling
- overhaul base layout with dark mode toggle and navigation includes
- restyle dashboard, forms, and teacher portal templates

## Testing
- `PYTHONPATH=src DJANGO_SETTINGS_MODULE=config.settings python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689e19c8dde08324ae89305f63ea91f0