### PR TITLE
Include CSRF token in HTMX requests

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -20,5 +20,10 @@
         {% block content %}{% endblock %}
     </main>
     {% include 'includes/footer.html' %}
+    <script>
+    document.body.addEventListener('htmx:configRequest', (e) => {
+        e.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+    });
+    </script>
 </body>
 </html>

--- a/templates/goal_kg.html
+++ b/templates/goal_kg.html
@@ -3,6 +3,7 @@
 {% block content %}
 <section x-data="goalKG()" class="grid gap-4 md:gap-6">
     <form hx-post="/api/goals/" hx-swap="none" @htmx:afterRequest="updateSmart" class="card grid gap-4 md:gap-5">
+        {% csrf_token %}
         <input type="hidden" name="user_session" value="{{ user_session_id }}">
         <label class="grid gap-1">
             <span class="text-sm font-medium">Was möchtest du erreichen?</span>

--- a/templates/goal_vg.html
+++ b/templates/goal_vg.html
@@ -4,6 +4,7 @@
 <div x-data="goalCoach()" class="grid gap-4 md:gap-6">
     <div id="chat" class="card h-64 overflow-y-auto space-y-2"></div>
     <form :hx-post="goalId ? '/api/vg/coach/next/' : '/api/vg/goals/'" hx-swap="none" @htmx:afterRequest="handleResponse" class="flex flex-col sm:flex-row gap-2">
+        {% csrf_token %}
         <input type="hidden" name="user_session" value="{{ user_session_id }}" x-show="!goalId">
         <input type="hidden" name="goal_id" :value="goalId" x-show="goalId">
         <textarea x-model="message" class="flex-1 rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" placeholder="Deine Nachricht..."></textarea>

--- a/templates/overall_goal.html
+++ b/templates/overall_goal.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h1 class="text-2xl md:text-3xl font-semibold tracking-tight mb-6">Gesamtziel festlegen</h1>
 <form hx-post="/api/overall-goal/" hx-swap="none" @htmx:afterRequest="window.location.href='{% url 'dashboard' %}'" class="grid gap-4 md:gap-5">
+    {% csrf_token %}
     <label class="grid gap-1">
         <span class="text-sm font-medium">Gesamtziel</span>
         <textarea name="text" rows="4" class="w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500">{{ goal.text|default:"" }}</textarea>

--- a/templates/reflection.html
+++ b/templates/reflection.html
@@ -3,6 +3,7 @@
 {% block content %}
 <section x-data="reflectionForm()" class="grid gap-4 md:gap-6">
     <form x-show="!submitted" hx-post="/api/reflections/" hx-swap="none" @htmx:afterRequest="handleResponse" class="card grid gap-4 md:gap-5">
+        {% csrf_token %}
         <input type="hidden" name="user_session" value="{{ user_session_id }}">
         <input type="hidden" name="goal" value="{{ goal_id }}">
         <div class="grid gap-2">


### PR DESCRIPTION
## Summary
- Attach CSRF token to all HTMX requests in base template
- Add CSRF tokens to HTMX forms for overall goal, KG goal, VG goal, and reflection

## Testing
- `python manage.py test tests.test_api.OverallGoalAPITests.test_create_overall_goal -v 2`
- `python manage.py test tests.test_api.OverallGoalAPITests.test_update_overall_goal -v 2`
- `python manage.py test tests.test_reflection.ReflectionEdgeCaseTests.test_validation_error -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689e236a3ed883249bd38134d04a43a4