### PR TITLE
Show OpenAI API key in site settings

### DIFF
--- a/src/teacher_portal/forms.py
+++ b/src/teacher_portal/forms.py
@@ -4,6 +4,7 @@ import io
 import openai
 from openai import OpenAIError
 from django import forms
+from django.urls import reverse_lazy
 
 from accounts.models import User
 from config.models import SiteSettings
@@ -15,7 +16,14 @@ class SiteSettingsForm(forms.ModelForm):
         model = SiteSettings
         fields = ["openai_api_key", "allow_ai"]
         widgets = {
-            "openai_api_key": forms.PasswordInput(render_value=True),
+            "openai_api_key": forms.TextInput(
+                attrs={
+                    "hx-post": reverse_lazy("teacher_portal:check_openai_key"),
+                    "hx-trigger": "change",
+                    "hx-target": "closest div",
+                    "hx-swap": "none",
+                }
+            ),
         }
 
     def clean_openai_api_key(self):


### PR DESCRIPTION
## Summary
- Display OpenAI API key using a TextInput widget with HTMX attributes for live validation
- Keep portal view initializing SiteSettingsForm with the stored SiteSettings instance

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689fc24b1e30832493f4b2fc8eae47f1