### PR TITLE
Use automatic htmx validation for OpenAI key

### DIFF
--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -16,7 +16,8 @@
             <h2 class="text-lg md:text-xl font-semibold mb-3">Site Settings</h2>
             <form method="post" x-data="{saved:false}" @submit.prevent="$el.submit(); saved=true; setTimeout(()=>saved=false,2000)" class="grid gap-4 md:gap-5">
                 {% csrf_token %}
-                <div x-data="{msg: '', ok: null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200; msg = ok ? 'API key valid' : 'API key invalid'" class="grid gap-4 md:gap-5">
+                {% url 'teacher_portal:check_openai_key' as check_openai_key_url %}
+                <div x-data="{ok: null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200" class="grid gap-4 md:gap-5">
                     <div>
                         {{ settings_form.allow_ai.label_tag }} {{ settings_form.allow_ai }}
                         {% if settings_form.allow_ai.errors %}<p class="text-red-500 text-sm">{{ settings_form.allow_ai.errors.0 }}</p>{% endif %}
@@ -24,12 +25,8 @@
                     <div>
                         {{ settings_form.openai_api_key.label_tag }}
                         <div class="flex items-center gap-2">
-                            {{ settings_form.openai_api_key|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
-                            <button type="button" class="btn-ghost"
-                                    hx-post="{% url 'teacher_portal:check_openai_key' %}"
-                                    hx-include="[name='openai_api_key']"
-                                    hx-swap="none">Test</button>
-                            <span x-show="msg" x-text="msg" x-transition :class="ok ? 'text-emerald-600' : 'text-red-600'"></span>
+                            {{ settings_form.openai_api_key.as_widget(attrs={'class': 'w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500', 'hx-post': check_openai_key_url, 'hx-trigger': 'keyup changed delay:500ms', 'hx-target': 'closest div', 'hx-swap': 'none'}) }}
+                            <span x-show="ok !== null" class="inline-block w-5 h-5 rounded-full" :class="ok ? 'bg-emerald-600' : 'bg-red-600'"></span>
                         </div>
                         {% if settings_form.openai_api_key.errors %}<p class="text-red-500 text-sm">{{ settings_form.openai_api_key.errors.0 }}</p>{% endif %}
                     </div>


### PR DESCRIPTION
## Summary
- Auto-validate OpenAI key input with htmx triggered on keyup/change
- Replace manual test button with color-coded status indicator

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'accounts')*

------
https://chatgpt.com/codex/tasks/task_e_689fc3c0133883249c3c47deab996876