### PR TITLE
Add generic template filter for merging widget attributes

### DIFF
--- a/src/config/templatetags/form_tags.py
+++ b/src/config/templatetags/form_tags.py
@@ -2,6 +2,13 @@ from django import template
 
 register = template.Library()
 
+@register.filter(name="add_attrs")
+def add_attrs(field, attrs):
+    merged_attrs = field.field.widget.attrs.copy()
+    merged_attrs.update(attrs)
+    field.field.widget.attrs = merged_attrs
+    return field
+
 @register.filter(name="add_class")
 def add_class(field, css):
     return field.as_widget(attrs={"class": (field.field.widget.attrs.get("class", "") + " " + css).strip()})

--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -25,7 +25,7 @@
                     <div>
                         {{ settings_form.openai_api_key.label_tag }}
                         <div class="flex items-center gap-2">
-                            {{ settings_form.openai_api_key.as_widget(attrs={'class': 'w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500', 'hx-post': check_openai_key_url, 'hx-trigger': 'keyup changed delay:500ms', 'hx-target': 'closest div', 'hx-swap': 'none'}) }}
+                            {{ settings_form.openai_api_key|add_attrs:{'hx-post': check_openai_key_url, 'hx-trigger': 'keyup changed delay:500ms', 'hx-target': 'closest div', 'hx-swap': 'none'}|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
                             <span x-show="ok !== null" class="inline-block w-5 h-5 rounded-full" :class="ok ? 'bg-emerald-600' : 'bg-red-600'"></span>
                         </div>
                         {% if settings_form.openai_api_key.errors %}<p class="text-red-500 text-sm">{{ settings_form.openai_api_key.errors.0 }}</p>{% endif %}


### PR DESCRIPTION
## Summary
- add `add_attrs` template filter to merge arbitrary widget attributes
- use `add_attrs` in teacher portal settings form for OpenAI key input

## Testing
- `python manage.py test tests.test_teacher_portal.TeacherPortalTests.test_portal_view` *(fails: TemplateSyntaxError: add_attrs requires 2 arguments, 1 provided)*

------
https://chatgpt.com/codex/tasks/task_e_689fc70373388324bfd4b09306905f2d