### PR TITLE
Fix template attribute filter usage in teacher portal

### DIFF
--- a/src/config/templatetags/form_tags.py
+++ b/src/config/templatetags/form_tags.py
@@ -2,6 +2,13 @@ from django import template
 
 register = template.Library()
 
+@register.filter(name="add_attrs")
+def add_attrs(field, attrs):
+    merged_attrs = field.field.widget.attrs.copy()
+    merged_attrs.update(attrs)
+    field.field.widget.attrs = merged_attrs
+    return field
+
 @register.filter(name="add_class")
 def add_class(field, css):
     return field.as_widget(attrs={"class": (field.field.widget.attrs.get("class", "") + " " + css).strip()})

--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -16,7 +16,6 @@
             <h2 class="text-lg md:text-xl font-semibold mb-3">Site Settings</h2>
             <form method="post" x-data="{saved:false}" @submit.prevent="$el.submit(); saved=true; setTimeout(()=>saved=false,2000)" class="grid gap-4 md:gap-5">
                 {% csrf_token %}
-                {% url 'teacher_portal:check_openai_key' as check_openai_key_url %}
                 <div x-data="{ok: null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200" class="grid gap-4 md:gap-5">
                     <div>
                         {{ settings_form.allow_ai.label_tag }} {{ settings_form.allow_ai }}
@@ -25,7 +24,7 @@
                     <div>
                         {{ settings_form.openai_api_key.label_tag }}
                         <div class="flex items-center gap-2">
-                            {{ settings_form.openai_api_key.as_widget(attrs={'class': 'w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500', 'hx-post': check_openai_key_url, 'hx-trigger': 'keyup changed delay:500ms', 'hx-target': 'closest div', 'hx-swap': 'none'}) }}
+                            {{ settings_form.openai_api_key|add_attrs:openai_attrs|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
                             <span x-show="ok !== null" class="inline-block w-5 h-5 rounded-full" :class="ok ? 'bg-emerald-600' : 'bg-red-600'"></span>
                         </div>
                         {% if settings_form.openai_api_key.errors %}<p class="text-red-500 text-sm">{{ settings_form.openai_api_key.errors.0 }}</p>{% endif %}

--- a/src/teacher_portal/views.py
+++ b/src/teacher_portal/views.py
@@ -1,6 +1,7 @@
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 
 from accounts.models import User
 from config.models import SiteSettings
@@ -33,6 +34,13 @@ def portal(request):
                 return redirect("teacher_portal:portal")
 
     classrooms = Classroom.objects.all()
+    check_openai_key_url = reverse("teacher_portal:check_openai_key")
+    openai_attrs = {
+        "hx-post": check_openai_key_url,
+        "hx-trigger": "keyup changed delay:500ms",
+        "hx-target": "closest div",
+        "hx-swap": "none",
+    }
     return render(
         request,
         "teacher_portal/portal.html",
@@ -40,6 +48,7 @@ def portal(request):
             "settings_form": settings_form,
             "classroom_form": classroom_form,
             "classrooms": classrooms,
+            "openai_attrs": openai_attrs,
         },
     )
 


### PR DESCRIPTION
## Summary
- supply HTMX attributes from the view context for the OpenAI key field
- use `add_attrs` filter with provided attributes before adding classes in the template

## Testing
- `python manage.py test tests.test_teacher_portal.TeacherPortalTests.test_portal_view -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689fc70373388324bfd4b09306905f2d