### PR TITLE
Refactor add_attrs filter to preserve widget attrs

### DIFF
--- a/src/config/templatetags/form_tags.py
+++ b/src/config/templatetags/form_tags.py
@@ -1,13 +1,11 @@
 from django import template
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
 @register.filter(name="add_attrs")
 def add_attrs(field, attrs):
-    merged_attrs = field.field.widget.attrs.copy()
-    merged_attrs.update(attrs)
-    field.field.widget.attrs = merged_attrs
-    return field
+    return mark_safe(field.as_widget(attrs={**field.field.widget.attrs, **attrs}))
 
 @register.filter(name="add_class")
 def add_class(field, css):

--- a/tests/test_form_tags.py
+++ b/tests/test_form_tags.py
@@ -1,0 +1,21 @@
+from django import forms
+from django.test import SimpleTestCase
+from django.utils.safestring import SafeString
+
+from config.templatetags.form_tags import add_attrs
+
+
+class AddAttrsFilterTests(SimpleTestCase):
+    def test_preserves_existing_and_adds_htmx_attrs(self):
+        class SampleForm(forms.Form):
+            name = forms.CharField(widget=forms.TextInput(attrs={"placeholder": "Existing"}))
+
+        form = SampleForm()
+        field = form["name"]
+
+        rendered = add_attrs(field, {"hx-post": "/post", "hx-target": "#id"})
+
+        self.assertIsInstance(rendered, SafeString)
+        self.assertIn('placeholder="Existing"', rendered)
+        self.assertIn('hx-post="/post"', rendered)
+        self.assertIn('hx-target="#id"', rendered)


### PR DESCRIPTION
## Summary
- Return a safe rendered widget from `add_attrs` instead of mutating the widget
- Cover `add_attrs` with tests ensuring existing and HTMX attributes coexist

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689fd747006c83248daa334d71c77b54