### PR TITLE
Ensure add_class preserves existing attributes

### DIFF
--- a/src/config/templatetags/form_tags.py
+++ b/src/config/templatetags/form_tags.py
@@ -5,8 +5,21 @@ register = template.Library()
 
 @register.filter(name="add_attrs")
 def add_attrs(field, attrs):
-    return mark_safe(field.as_widget(attrs={**field.field.widget.attrs, **attrs}))
+    """Add arbitrary attributes to a form field's widget.
+
+    Updates ``field.field.widget.attrs`` in place so that subsequent filters
+    (e.g. :func:`add_class`) operate on the augmented attribute set.
+    """
+    field.field.widget.attrs.update(attrs)
+    return mark_safe(field.as_widget())
 
 @register.filter(name="add_class")
 def add_class(field, css):
-    return field.as_widget(attrs={"class": (field.field.widget.attrs.get("class", "") + " " + css).strip()})
+    """Append a CSS class to the field's widget.
+
+    The class is appended directly onto ``field.field.widget.attrs['class']``
+    to avoid clobbering previously added attributes (such as HTMX attrs).
+    """
+    existing_classes = field.field.widget.attrs.get("class", "")
+    field.field.widget.attrs["class"] = (existing_classes + " " + css).strip()
+    return field.as_widget()

--- a/tests/test_form_tags.py
+++ b/tests/test_form_tags.py
@@ -1,8 +1,11 @@
 from django import forms
 from django.test import SimpleTestCase
 from django.utils.safestring import SafeString
+import django
 
-from config.templatetags.form_tags import add_attrs
+django.setup()
+
+from config.templatetags.form_tags import add_attrs, add_class
 
 
 class AddAttrsFilterTests(SimpleTestCase):
@@ -19,3 +22,20 @@ class AddAttrsFilterTests(SimpleTestCase):
         self.assertIn('placeholder="Existing"', rendered)
         self.assertIn('hx-post="/post"', rendered)
         self.assertIn('hx-target="#id"', rendered)
+
+
+class CombinedFiltersTests(SimpleTestCase):
+    def test_add_attrs_then_add_class_preserves_htmx_and_class(self):
+        class SampleForm(forms.Form):
+            name = forms.CharField(widget=forms.TextInput(attrs={"placeholder": "Existing"}))
+
+        form = SampleForm()
+        field = form["name"]
+
+        add_attrs(field, {"hx-post": "/post", "hx-trigger": "keyup"})
+        rendered = add_class(field, "btn")
+
+        self.assertIn('placeholder="Existing"', rendered)
+        self.assertIn('hx-post="/post"', rendered)
+        self.assertIn('hx-trigger="keyup"', rendered)
+        self.assertIn('class="btn"', rendered)


### PR DESCRIPTION
## Summary
- prevent `add_class` filter from discarding existing widget attributes
- allow `add_attrs` to persist attributes for subsequent filters
- test combined filters retain HTMX attributes and classes

## Testing
- `PYTHONPATH=src DJANGO_SETTINGS_MODULE=config.settings pytest tests/test_form_tags.py -q`
- `PYTHONPATH=src DJANGO_SETTINGS_MODULE=config.settings pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fda682c3c8324a88dc6067ec20ac0