### PR TITLE
Handle missing openai attrs in teacher portal template

### DIFF
--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -21,6 +21,7 @@
                         {{ settings_form.allow_ai.label_tag }} {{ settings_form.allow_ai }}
                         {% if settings_form.allow_ai.errors %}<p class="text-red-500 text-sm">{{ settings_form.allow_ai.errors.0 }}</p>{% endif %}
                     </div>
+                    {% with openai_attrs|default:settings_form.openai_api_key.field.widget.attrs as openai_attrs %}
                     <div>
                         {{ settings_form.openai_api_key.label_tag }}
                         <div class="flex items-center gap-2">
@@ -32,6 +33,7 @@
                         </div>
                         {% if settings_form.openai_api_key.errors %}<p class="text-red-500 text-sm">{{ settings_form.openai_api_key.errors.0 }}</p>{% endif %}
                     </div>
+                    {% endwith %}
                 </div>
                 <p x-show="saved" x-transition class="text-emerald-600">Gespeichert</p>
                 <button type="submit" name="save_settings" class="btn-primary mt-2">Save</button>

--- a/tests/test_teacher_portal.py
+++ b/tests/test_teacher_portal.py
@@ -1,9 +1,12 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.template.loader import render_to_string
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
 from accounts.models import User
 from lessons.models import Classroom
+from teacher_portal.forms import ClassroomForm, SiteSettingsForm
+from config.models import SiteSettings
 
 
 class TeacherPortalTests(TestCase):
@@ -51,3 +54,13 @@ class TeacherPortalTests(TestCase):
         url = reverse("teacher_portal:portal")
         resp = self.client.get(url)
         assert resp.status_code == 302
+
+    def test_template_renders_without_openai_attrs(self):
+        rf = RequestFactory()
+        request = rf.get("/")
+        context = {
+            "settings_form": SiteSettingsForm(instance=SiteSettings.get()),
+            "classroom_form": ClassroomForm(),
+            "classrooms": [],
+        }
+        render_to_string("teacher_portal/portal.html", context=context, request=request)


### PR DESCRIPTION
## Summary
- Guard portal OpenAI API key field with a `{% with %}` block that provides default attrs when the view fails to supply `openai_attrs`
- Add regression test ensuring template renders without `openai_attrs`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689fdc281604832482b5b6b51d057a76