### PR TITLE
Fix OpenAI key field rendering in Teacher Portal

### DIFF
--- a/src/config/templatetags/form_tags.py
+++ b/src/config/templatetags/form_tags.py
@@ -1,5 +1,5 @@
+from collections.abc import Mapping
 from django import template
-from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -9,9 +9,11 @@ def add_attrs(field, attrs):
 
     Updates ``field.field.widget.attrs`` in place so that subsequent filters
     (e.g. :func:`add_class`) operate on the augmented attribute set.
+    Returns the original field so filters can be chained in templates.
     """
-    field.field.widget.attrs.update(attrs)
-    return mark_safe(field.as_widget())
+    if isinstance(attrs, Mapping):
+        field.field.widget.attrs.update(attrs)
+    return field
 
 @register.filter(name="add_class")
 def add_class(field, css):

--- a/src/teacher_portal/forms.py
+++ b/src/teacher_portal/forms.py
@@ -12,6 +12,7 @@ from lessons.models import Classroom
 
 
 class SiteSettingsForm(forms.ModelForm):
+    allow_ai = forms.BooleanField(required=False)
     class Meta:
         model = SiteSettings
         fields = ["openai_api_key", "allow_ai"]

--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -25,9 +25,7 @@
                     <div>
                         {{ settings_form.openai_api_key.label_tag }}
                         <div class="flex items-center gap-2">
-                            {{ settings_form.openai_api_key
-   |add_attrs:openai_attrs
-   |add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700" }}
+                            {{ settings_form.openai_api_key|add_attrs:openai_attrs|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700" }}
 
                             <span x-show="ok !== null" class="inline-block w-5 h-5 rounded-full" :class="ok ? 'bg-emerald-600' : 'bg-red-600'"></span>
                         </div>

--- a/tests/test_form_tags.py
+++ b/tests/test_form_tags.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.test import SimpleTestCase
-from django.utils.safestring import SafeString
 import django
 
 django.setup()
@@ -16,9 +15,9 @@ class AddAttrsFilterTests(SimpleTestCase):
         form = SampleForm()
         field = form["name"]
 
-        rendered = add_attrs(field, {"hx-post": "/post", "hx-target": "#id"})
+        result = add_attrs(field, {"hx-post": "/post", "hx-target": "#id"})
+        rendered = result.as_widget()
 
-        self.assertIsInstance(rendered, SafeString)
         self.assertIn('placeholder="Existing"', rendered)
         self.assertIn('hx-post="/post"', rendered)
         self.assertIn('hx-target="#id"', rendered)
@@ -32,8 +31,10 @@ class CombinedFiltersTests(SimpleTestCase):
         form = SampleForm()
         field = form["name"]
 
-        add_attrs(field, {"hx-post": "/post", "hx-trigger": "keyup"})
-        rendered = add_class(field, "btn")
+        rendered = add_class(
+            add_attrs(field, {"hx-post": "/post", "hx-trigger": "keyup"}),
+            "btn",
+        )
 
         self.assertIn('placeholder="Existing"', rendered)
         self.assertIn('hx-post="/post"', rendered)


### PR DESCRIPTION
## Summary
- fix `add_attrs` filter to allow chaining and ignore invalid attrs
- make `allow_ai` optional and render OpenAI key field properly
- adjust form tag tests

## Testing
- `PYTHONPATH=src python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689feabec6f883248556aad76003f1f8