### PR TITLE
style: refine OpenAI API key field styling

### DIFF
--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -25,7 +25,7 @@
                     <div>
                         {{ settings_form.openai_api_key.label_tag }}
                         <div class="flex items-center gap-2">
-                            {{ settings_form.openai_api_key|add_attrs:openai_attrs|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700" }}
+                            {{ settings_form.openai_api_key|add_attrs:openai_attrs|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
 
                             <span x-show="ok !== null" class="inline-block w-5 h-5 rounded-full" :class="ok ? 'bg-emerald-600' : 'bg-red-600'"></span>
                         </div>


### PR DESCRIPTION
## Summary
- apply light/dark mode and focus ring styles to OpenAI API key field

## Testing
- `pytest` (fails: ModuleNotFoundError for various Django apps and missing settings)


------
https://chatgpt.com/codex/tasks/task_e_689ff0a260bc8324ba55d66709ccfd4a