### PR TITLE
Ensure OpenAI API key persists in teacher portal form

### DIFF
--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -21,7 +21,7 @@
                         {{ settings_form.allow_ai.label_tag }} {{ settings_form.allow_ai }}
                         {% if settings_form.allow_ai.errors %}<p class="text-red-500 text-sm">{{ settings_form.allow_ai.errors.0 }}</p>{% endif %}
                     </div>
-                    {% with openai_attrs|default:settings_form.openai_api_key.field.widget.attrs as openai_attrs %}
+                    {% with openai_attrs=openai_attrs|default:"" %}
                     <div>
                         {{ settings_form.openai_api_key.label_tag }}
                         <div class="flex items-center gap-2">

--- a/src/teacher_portal/views.py
+++ b/src/teacher_portal/views.py
@@ -40,6 +40,7 @@ def portal(request):
         "hx-trigger": "keyup changed delay:500ms",
         "hx-target": "closest div",
         "hx-swap": "none",
+        "value": settings_form["openai_api_key"].value() or "",
     }
     return render(
         request,

--- a/tests/test_teacher_portal.py
+++ b/tests/test_teacher_portal.py
@@ -64,3 +64,11 @@ class TeacherPortalTests(TestCase):
             "classrooms": [],
         }
         render_to_string("teacher_portal/portal.html", context=context, request=request)
+
+    def test_saved_openai_key_is_rendered(self):
+        settings = SiteSettings.get()
+        settings.openai_api_key = "db-key"
+        settings.save()
+        url = reverse("teacher_portal:portal")
+        resp = self.client.get(url)
+        assert b"db-key" in resp.content


### PR DESCRIPTION
## Summary
- Preserve the saved OpenAI API key in teacher portal settings by binding it to the form input after redirects
- Allow template to render without optional `openai_attrs`
- Add regression test checking API key visibility in portal form

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689ff180c69c83249fe6724f5c3eb913