### PR TITLE
Refine OpenAI key validation in teacher portal

### DIFF
--- a/src/teacher_portal/templates/teacher_portal/portal.html
+++ b/src/teacher_portal/templates/teacher_portal/portal.html
@@ -16,7 +16,7 @@
             <h2 class="text-lg md:text-xl font-semibold mb-3">Site Settings</h2>
             <form method="post" x-data="{saved:false}" @submit.prevent="$el.submit(); saved=true; setTimeout(()=>saved=false,2000)" class="grid gap-4 md:gap-5">
                 {% csrf_token %}
-                <div x-data="{ok: null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200" class="grid gap-4 md:gap-5">
+                <div class="grid gap-4 md:gap-5">
                     <div>
                         {{ settings_form.allow_ai.label_tag }} {{ settings_form.allow_ai }}
                         {% if settings_form.allow_ai.errors %}<p class="text-red-500 text-sm">{{ settings_form.allow_ai.errors.0 }}</p>{% endif %}
@@ -24,10 +24,10 @@
                     {% with openai_attrs=openai_attrs|default:"" %}
                     <div>
                         {{ settings_form.openai_api_key.label_tag }}
-                        <div class="flex items-center gap-2">
+                        <div class="flex items-center gap-2" x-data="{ok:null}" @htmx:afterRequest="ok = $event.detail.xhr.status === 200">
                             {{ settings_form.openai_api_key|add_attrs:openai_attrs|add_class:"w-full rounded-xl border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" }}
 
-                            <span x-show="ok !== null" class="inline-block w-5 h-5 rounded-full" :class="ok ? 'bg-emerald-600' : 'bg-red-600'"></span>
+                            <span x-show="ok !== null" hx-indicator class="inline-block w-5 h-5 rounded-full" :class="ok ? 'bg-emerald-600' : 'bg-red-600'"></span>
                         </div>
                         {% if settings_form.openai_api_key.errors %}<p class="text-red-500 text-sm">{{ settings_form.openai_api_key.errors.0 }}</p>{% endif %}
                     </div>

--- a/src/teacher_portal/views.py
+++ b/src/teacher_portal/views.py
@@ -37,7 +37,7 @@ def portal(request):
     check_openai_key_url = reverse("teacher_portal:check_openai_key")
     openai_attrs = {
         "hx-post": check_openai_key_url,
-        "hx-trigger": "keyup changed delay:500ms",
+        "hx-trigger": "keyup change delay:500ms",
         "hx-target": "closest div",
         "hx-swap": "none",
         "value": settings_form["openai_api_key"].value() or "",


### PR DESCRIPTION
## Summary
- Move OpenAI API key check state management to the HTMX target element
- Show status feedback via `hx-indicator` circle
- Align `openai_attrs` trigger and target with template behavior

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689ff3cfaf588324959ca3dd3302d5d1