### PR TITLE
Add admin registrations for classroom models

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -1,3 +1,27 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Classroom, Student, LearningGoal
+
+
+class StudentInline(admin.TabularInline):
+    model = Student
+    extra = 1
+
+
+@admin.register(Classroom)
+class ClassroomAdmin(admin.ModelAdmin):
+    list_display = ["name", "teacher", "group_type"]
+    list_filter = ["teacher", "group_type"]
+    inlines = [StudentInline]
+
+
+@admin.register(Student)
+class StudentAdmin(admin.ModelAdmin):
+    list_display = ["pseudonym", "classroom"]
+    list_filter = ["classroom"]
+
+
+@admin.register(LearningGoal)
+class LearningGoalAdmin(admin.ModelAdmin):
+    list_display = ["student", "session_date", "achieved"]
+    list_filter = ["achieved", "session_date"]


### PR DESCRIPTION
## Summary
- register Classroom, Student, and LearningGoal in Django admin
- add inline Student form and list filters to Classroom admin

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689fff9affd0832494184f3805e7003f