### PR TITLE
Configure authentication for dashboard

### DIFF
--- a/EduNav/settings.py
+++ b/EduNav/settings.py
@@ -55,7 +55,7 @@ ROOT_URLCONF = 'EduNav.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -117,6 +117,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = 'static/'
+
+# Authentication settings
+LOGIN_URL = 'login'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field

--- a/EduNav/urls.py
+++ b/EduNav/urls.py
@@ -19,4 +19,5 @@ from django.urls import include, path
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("dashboard/", include("dashboard.urls")),
+    path("", include("django.contrib.auth.urls")),
 ]

--- a/templates/registration/logged_out.html
+++ b/templates/registration/logged_out.html
@@ -1,0 +1,6 @@
+{% extends "dashboard/base.html" %}
+
+{% block content %}
+  <p>You have been logged out.</p>
+  <a href="{% url 'login' %}">Login again</a>
+{% endblock %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,10 @@
+{% extends "dashboard/base.html" %}
+
+{% block content %}
+  <h2>Login</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Login</button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add global templates directory and set LOGIN_URL
- Include Django auth login and logout URLs
- Provide basic login and logout templates

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a00651d4708324ad2867ccf5d37f8b