### PR TITLE
Add modal class creation with modern UI

### DIFF
--- a/dashboard/forms.py
+++ b/dashboard/forms.py
@@ -6,12 +6,33 @@ class ClassroomForm(forms.ModelForm):
     class Meta:
         model = Classroom
         fields = ["name", "group_type"]
+        widgets = {
+            "name": forms.TextInput(
+                attrs={
+                    "class": "block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5",
+                    "placeholder": "Klassenname",
+                }
+            ),
+            "group_type": forms.Select(
+                attrs={
+                    "class": "block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5",
+                }
+            ),
+        }
 
 
 class StudentForm(forms.ModelForm):
     class Meta:
         model = Student
         fields = ["pseudonym"]
+        widgets = {
+            "pseudonym": forms.TextInput(
+                attrs={
+                    "class": "block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5",
+                    "placeholder": "Pseudonym",
+                }
+            ),
+        }
 
 
 class LearningGoalForm(forms.ModelForm):

--- a/dashboard/templates/dashboard/base.html
+++ b/dashboard/templates/dashboard/base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>EduNav</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3/dist/tailwind.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/flowbite@2.4.1/dist/flowbite.min.css" rel="stylesheet" />
 </head>
 <body class="bg-gray-100">
     <nav class="bg-white shadow p-4 flex justify-between">
@@ -13,5 +14,7 @@
     <main class="container mx-auto p-6">
         {% block content %}{% endblock %}
     </main>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="https://cdn.jsdelivr.net/npm/flowbite@2.4.1/dist/flowbite.min.js"></script>
 </body>
 </html>

--- a/dashboard/templates/dashboard/classroom_form.html
+++ b/dashboard/templates/dashboard/classroom_form.html
@@ -1,0 +1,17 @@
+<div class="p-4">
+    <form hx-post="{% url 'classroom_create' %}" hx-target="#classroom-modal" hx-swap="outerHTML">
+        {% csrf_token %}
+        <div class="mb-4">
+            <label for="id_name" class="block mb-2 text-sm font-medium text-gray-900">Klassenname</label>
+            {{ form.name }}
+        </div>
+        <div class="mb-4">
+            <label for="id_group_type" class="block mb-2 text-sm font-medium text-gray-900">Gruppe</label>
+            {{ form.group_type }}
+        </div>
+        <div class="flex justify-end space-x-2">
+            <button type="button" data-modal-hide="classroom-modal" class="text-gray-500 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 rounded-lg text-sm px-5 py-2.5">Abbrechen</button>
+            <button type="submit" class="text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5">Speichern</button>
+        </div>
+    </form>
+</div>

--- a/dashboard/templates/dashboard/classroom_list.html
+++ b/dashboard/templates/dashboard/classroom_list.html
@@ -1,16 +1,39 @@
 {% extends "dashboard/base.html" %}
 {% block content %}
-<h1 class="text-2xl mb-4">Klassenräume</h1>
-<a href="{% url 'classroom_create' %}" class="bg-blue-500 text-white px-4 py-2 rounded">Neue Klasse</a>
-<div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+<div class="flex items-center justify-between mb-4">
+    <h1 class="text-2xl">Klassenräume</h1>
+    <button data-modal-target="classroom-modal" data-modal-toggle="classroom-modal" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm">Neue Klasse</button>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4" id="classroom-list">
     {% for classroom in classrooms %}
-        <div class="bg-white p-4 rounded shadow">
-            <h2 class="text-xl font-semibold">{{ classroom.name }}</h2>
-            <p>AI-Modus: {{ classroom.get_group_type_display }}</p>
-            <a href="{% url 'student_list' classroom.id %}" class="text-blue-600">Schüler verwalten</a>
+        <div class="bg-white rounded-lg shadow p-6">
+            <div class="flex items-center justify-between mb-2">
+                <h2 class="text-xl font-semibold">{{ classroom.name }}</h2>
+                <span class="text-xs font-medium px-2.5 py-0.5 rounded {% if classroom.group_type == 'EXPERIMENTAL' %}bg-green-100 text-green-800{% else %}bg-gray-100 text-gray-800{% endif %}">
+                    {{ classroom.get_group_type_display }}
+                </span>
+            </div>
+            <a href="{% url 'student_list' classroom.id %}" class="text-blue-600 hover:underline">Schüler verwalten</a>
         </div>
     {% empty %}
         <p>Keine Klassenräume vorhanden.</p>
     {% endfor %}
+</div>
+
+<!-- Modal container -->
+<div id="classroom-modal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+  <div class="relative p-4 w-full max-w-md max-h-full">
+    <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+      <div class="flex items-center justify-between p-4 border-b rounded-t dark:border-gray-600">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Neue Klasse</h3>
+        <button type="button" class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ml-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white" data-modal-hide="classroom-modal">
+          <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1l12 12M13 1L1 13"/></svg>
+          <span class="sr-only">Close modal</span>
+        </button>
+      </div>
+      <div id="classroom-form-container" hx-get="{% url 'classroom_create' %}" hx-trigger="revealed" hx-target="#classroom-form-container" hx-swap="innerHTML"></div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect, get_object_or_404
+from django.http import HttpResponse
+from django.urls import reverse
 from .models import Classroom, Student
 from .forms import ClassroomForm, StudentForm
 
@@ -18,6 +20,10 @@ def classroom_create(request):
             classroom = form.save(commit=False)
             classroom.teacher = request.user
             classroom.save()
+            if request.headers.get("HX-Request"):
+                response = HttpResponse()
+                response["HX-Redirect"] = reverse("classroom_list")
+                return response
             return redirect("classroom_list")
     else:
         form = ClassroomForm()


### PR DESCRIPTION
## Summary
- Style form widgets for Tailwind look-and-feel
- Add Flowbite & HTMX to base layout and implement modal for class creation
- Handle HTMX redirects in classroom creation view

## Testing
- `DJANGO_SETTINGS_MODULE=EduNav.settings pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ffab91d9083249ab927d6ba7643f6