### PR TITLE
Remove duplicate student management link and enforce modal usage

### DIFF
--- a/dashboard/templates/dashboard/classroom_list.html
+++ b/dashboard/templates/dashboard/classroom_list.html
@@ -23,7 +23,6 @@
                 class="text-blue-600 hover:underline">
                 Schüler verwalten
             </button>
-            <a href="{% url 'student_list' classroom.id %}" class="text-blue-600 hover:underline">Schüler verwalten</a>
         </div>
     {% empty %}
         <p>Keine Klassenräume vorhanden.</p>

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -32,6 +32,8 @@ def classroom_create(request):
 
 @login_required
 def student_list(request, classroom_id):
+    if not request.headers.get("HX-Request"):
+        return redirect("classroom_list")
     classroom = get_object_or_404(Classroom, id=classroom_id, teacher=request.user)
     students = classroom.students.all()
     form = StudentForm()


### PR DESCRIPTION
## Summary
- remove redundant classroom student management link
- prevent direct navigation to student management by redirecting non-HTMX requests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a0112ca17483249419d69b1416c2f2