### PR TITLE
Fix template error when rendering reflection fields

### DIFF
--- a/dashboard/templates/dashboard/student_dashboard.html
+++ b/dashboard/templates/dashboard/student_dashboard.html
@@ -1,4 +1,5 @@
 {% extends "dashboard/base.html" %}
+{% load form_tags %}
 
 {% block content %}
 <h2 class="text-2xl font-bold mb-4">Hallo {{ student.pseudonym }}</h2>
@@ -227,13 +228,13 @@
             <div class="mb-4">
               <label class="block mb-2">Was habe ich fachlich gelernt?</label>
               {% with field_id="learned-subject-"|add:entry.id %}
-                {{ reflection_form.learned_subject.as_widget(attrs={"id": field_id}) }}
+                {{ reflection_form.learned_subject|add_id:field_id }}
               {% endwith %}
             </div>
             <div class="mb-4">
               <label class="block mb-2">Was habe ich über meine Arbeitsweise gelernt?</label>
               {% with field_id="learned-work-"|add:entry.id %}
-                {{ reflection_form.learned_work.as_widget(attrs={"id": field_id}) }}
+                {{ reflection_form.learned_work|add_id:field_id }}
               {% endwith %}
             </div>
 
@@ -242,13 +243,13 @@
             <div class="mb-4">
               <label class="block mb-2">War meine Planung realistisch?</label>
               {% with field_id="planning-realistic-"|add:entry.id %}
-                {{ reflection_form.planning_realistic.as_widget(attrs={"id": field_id}) }}
+                {{ reflection_form.planning_realistic|add_id:field_id }}
               {% endwith %}
             </div>
             <div class="mb-4">
               <label class="block mb-2">Wo gab es Abweichungen?</label>
               {% with field_id="planning-deviations-"|add:entry.id %}
-                {{ reflection_form.planning_deviations.as_widget(attrs={"id": field_id}) }}
+                {{ reflection_form.planning_deviations|add_id:field_id }}
               {% endwith %}
             </div>
 
@@ -257,13 +258,13 @@
             <div class="mb-4">
               <label class="block mb-2">Wie bewerte ich meine Motivation über die Zeit hinweg?</label>
               {% with field_id="motivation-rating-"|add:entry.id %}
-                {{ reflection_form.motivation_rating.as_widget(attrs={"id": field_id}) }}
+                {{ reflection_form.motivation_rating|add_id:field_id }}
               {% endwith %}
             </div>
             <div class="mb-4">
               <label class="block mb-2">Was könnte ich tun, um sie zu stärken?</label>
               {% with field_id="motivation-improve-"|add:entry.id %}
-                {{ reflection_form.motivation_improve.as_widget(attrs={"id": field_id}) }}
+                {{ reflection_form.motivation_improve|add_id:field_id }}
               {% endwith %}
             </div>
 
@@ -272,13 +273,13 @@
             <div class="mb-4">
               <label class="block mb-2">Was nehme ich mir für die nächste Phase konkret vor?</label>
               {% with field_id="next-phase-"|add:entry.id %}
-                {{ reflection_form.next_phase.as_widget(attrs={"id": field_id}) }}
+                {{ reflection_form.next_phase|add_id:field_id }}
               {% endwith %}
             </div>
             <div class="mb-4">
               <label class="block mb-2">Welche Strategien will ich beibehalten oder ändern?</label>
               {% with field_id="strategy-outlook-"|add:entry.id %}
-                {{ reflection_form.strategy_outlook.as_widget(attrs={"id": field_id}) }}
+                {{ reflection_form.strategy_outlook|add_id:field_id }}
               {% endwith %}
             </div>
 

--- a/dashboard/templatetags/form_tags.py
+++ b/dashboard/templatetags/form_tags.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def add_id(field, new_id):
+    """Render a form field with a different HTML id attribute."""
+    return field.as_widget(attrs={"id": new_id})


### PR DESCRIPTION
## Summary
- add `add_id` template filter to safely set form field ids
- use the new filter to render reflection fields with unique IDs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a088918c8483248136d211a6ee6bdf