### PR TITLE
Refine timeline UI and center execution modal

### DIFF
--- a/dashboard/templates/dashboard/student_dashboard.html
+++ b/dashboard/templates/dashboard/student_dashboard.html
@@ -60,13 +60,14 @@
   <div class="timeline-entry" data-entry="{{ entry.id }}">
     <div class="timeline-card inactive bg-white p-6 rounded-lg shadow mx-auto w-full max-w-xl">
       <h4 class="font-bold text-center text-lg">{{ entry.session_date }}</h4>
+      <h5 class="font-semibold mt-4 mb-2">Planung</h5>
 
       {% if entry.goals %}
       <div class="mt-4">
-        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>Ziele</p>
+        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="3"/></svg>Ziele</p>
         <ul class="mt-1 space-y-1">
           {% for g in entry.goals %}
-          <li class="flex items-start"><svg class="w-4 h-4 mr-2 text-green-600 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg><span>{{ g }}</span></li>
+          <li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>{{ g }}</span></li>
           {% endfor %}
         </ul>
       </div>
@@ -81,7 +82,7 @@
 
       {% if entry.strategies %}
       <div class="mt-4">
-        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2"/></svg>Strategien</p>
+        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2a7 7 0 00-7 7c0 2.38 1.19 4.47 3 5.74V17a2 2 0 002 2h4a2 2 0 002-2v-2.26c1.81-1.27 3-3.36 3-5.74a7 7 0 00-7-7z"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 21h6"/></svg>Strategien</p>
         <div class="flex flex-wrap gap-2 mt-1">
           {% for s in entry.strategies %}
           <span class="px-2 py-1 bg-purple-100 text-purple-800 rounded-full text-sm">{{ s }}</span>
@@ -103,7 +104,7 @@
 
       {% if entry.time_planning %}
       <div class="mt-4">
-        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3"/></svg>Zeitplanung</p>
+        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3"/></svg>Zeitplanung</p>
         <ul class="mt-1 space-y-1 text-sm">
           {% for t in entry.time_planning %}
           <li class="flex justify-between bg-gray-50 px-2 py-1 rounded"><span>{{ t.goal }}</span><span class="text-gray-600">{{ t.time }}</span></li>
@@ -162,39 +163,57 @@
       {% if entry.goal_achievement %}
       <div class="mt-6 border-t pt-4">
         <h5 class="font-semibold mb-2">Reflexion</h5>
-        <p class="font-semibold">Zielerreichung</p>
-        <ul class="mt-1 space-y-1 text-sm">
-          {% for ga in entry.goal_achievement %}
-          <li>{{ ga.goal }}: {{ ga.achievement }}{% if ga.comment %} – {{ ga.comment }}{% endif %}</li>
-          {% endfor %}
-        </ul>
+
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>Zielerreichung</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% for ga in entry.goal_achievement %}
+            <li class="flex items-start"><svg class="w-4 h-4 mr-2 text-green-600 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg><span>{{ ga.goal }}: {{ ga.achievement }}{% if ga.comment %} – {{ ga.comment }}{% endif %}</span></li>
+            {% endfor %}
+          </ul>
+        </div>
+
         {% if entry.strategy_evaluation %}
-        <p class="font-semibold mt-4">Strategie</p>
-        <ul class="mt-1 space-y-1 text-sm">
-          {% for se in entry.strategy_evaluation %}
-          <li>{{ se.strategy }}: {{ se.helpful }}{% if se.reason %} – {{ se.reason }}{% endif %} (erneut: {{ se.reuse }})</li>
-          {% endfor %}
-        </ul>
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2a7 7 0 00-7 7c0 2.38 1.19 4.47 3 5.74V17a2 2 0 002 2h4a2 2 0 002-2v-2.26c1.81-1.27 3-3.36 3-5.74a7 7 0 00-7-7z"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 21h6"/></svg>Strategie</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% for se in entry.strategy_evaluation %}
+            <li class="flex items-start"><svg class="w-4 h-4 mr-2 text-purple-600 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2a7 7 0 00-7 7c0 2.38 1.19 4.47 3 5.74V17a2 2 0 002 2h4a2 2 0 002-2v-2.26c1.81-1.27 3-3.36 3-5.74a7 7 0 00-7-7z"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 21h6"/></svg><span>{{ se.strategy }}: {{ se.helpful }}{% if se.reason %} – {{ se.reason }}{% endif %} (erneut: {{ se.reuse }})</span></li>
+            {% endfor %}
+          </ul>
+        </div>
         {% endif %}
+
         {% if entry.learned_subject or entry.learned_work %}
-        <p class="font-semibold mt-4">Selbsteinschätzung</p>
-        {% if entry.learned_subject %}<p>Fachlich: {{ entry.learned_subject }}</p>{% endif %}
-        {% if entry.learned_work %}<p>Arbeitsweise: {{ entry.learned_work }}</p>{% endif %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 14l9-5-9-5-9 5 9 5z"/><path stroke-linecap="round" stroke-linejoin="round" d="M12 14l6.16-3.422A12.083 12.083 0 0118 20.944V21l-6-3-6 3v-.056a12.083 12.083 0 01-.16-10.367L12 14z"/></svg>Selbsteinschätzung</p>
+          {% if entry.learned_subject %}<p class="mt-1 text-sm">Fachlich: {{ entry.learned_subject }}</p>{% endif %}
+          {% if entry.learned_work %}<p class="mt-1 text-sm">Arbeitsweise: {{ entry.learned_work }}</p>{% endif %}
+        </div>
         {% endif %}
+
         {% if entry.planning_realistic or entry.planning_deviations %}
-        <p class="font-semibold mt-4">Zeitmanagement</p>
-        {% if entry.planning_realistic %}<p>Planung realistisch: {{ entry.planning_realistic }}</p>{% endif %}
-        {% if entry.planning_deviations %}<p>Abweichungen: {{ entry.planning_deviations }}</p>{% endif %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3"/></svg>Zeitmanagement</p>
+          {% if entry.planning_realistic %}<p class="mt-1 text-sm">Planung realistisch: {{ entry.planning_realistic }}</p>{% endif %}
+          {% if entry.planning_deviations %}<p class="mt-1 text-sm">Abweichungen: {{ entry.planning_deviations }}</p>{% endif %}
+        </div>
         {% endif %}
+
         {% if entry.motivation_rating or entry.motivation_improve %}
-        <p class="font-semibold mt-4">Emotionen/Motivation</p>
-        {% if entry.motivation_rating %}<p>Motivation: {{ entry.motivation_rating }}</p>{% endif %}
-        {% if entry.motivation_improve %}<p>Stärken: {{ entry.motivation_improve }}</p>{% endif %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1 text-red-500" fill="currentColor" viewBox="0 0 24 24"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6 3.99 4 6.5 4c1.74 0 3.41 1.01 4.13 2.44h.74C13.09 5.01 14.76 4 16.5 4 19.01 4 21 6 21 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>Emotionen/Motivation</p>
+          {% if entry.motivation_rating %}<p class="mt-1 text-sm">Motivation: {{ entry.motivation_rating }}</p>{% endif %}
+          {% if entry.motivation_improve %}<p class="mt-1 text-sm">Stärken: {{ entry.motivation_improve }}</p>{% endif %}
+        </div>
         {% endif %}
+
         {% if entry.next_phase or entry.strategy_outlook %}
-        <p class="font-semibold mt-4">Ausblick</p>
-        {% if entry.next_phase %}<p>Nächste Phase: {{ entry.next_phase }}</p>{% endif %}
-        {% if entry.strategy_outlook %}<p>Strategien: {{ entry.strategy_outlook }}</p>{% endif %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5-5 5M6 7l5 5-5 5"/></svg>Ausblick</p>
+          {% if entry.next_phase %}<p class="mt-1 text-sm">Nächste Phase: {{ entry.next_phase }}</p>{% endif %}
+          {% if entry.strategy_outlook %}<p class="mt-1 text-sm">Strategien: {{ entry.strategy_outlook }}</p>{% endif %}
+        </div>
         {% endif %}
       </div>
       {% endif %}
@@ -202,7 +221,7 @@
   </div>
 
   <!-- Execution Modal -->
-  <div id="executionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+  <div id="executionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
     <div class="relative p-4 w-full max-w-2xl max-h-full">
       <div class="relative bg-white rounded-lg shadow modal-content">
         <div class="p-4">
@@ -396,7 +415,7 @@
 </div>
 
 <!-- Planning Modal -->
-<div id="planningModal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+<div id="planningModal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
   <div class="relative p-4 w-full max-w-2xl max-h-full">
     <div class="relative bg-white rounded-lg shadow modal-content">
       <div class="p-4">


### PR DESCRIPTION
## Summary
- Center execution and planning modals
- Add planning section heading and adjust icons for goals, strategies, time planning
- Style reflection section with icons and improved layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a24d9eac3c8324a0a6a99c9f0264cf