### PR TITLE
Enhance timeline layout and modal centering

### DIFF
--- a/dashboard/templates/dashboard/student_dashboard.html
+++ b/dashboard/templates/dashboard/student_dashboard.html
@@ -61,65 +61,71 @@
     <div class="timeline-card inactive bg-white p-6 rounded-lg shadow mx-auto w-full max-w-xl">
       <h4 class="font-bold text-center text-lg">{{ entry.session_date }}</h4>
 
-      {% if entry.goals %}
+      {% if entry.goals or entry.priorities or entry.strategies or entry.resources or entry.time_planning or entry.expectations %}
       <div class="mt-4">
-        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>Ziele</p>
-        <ul class="mt-1 space-y-1">
-          {% for g in entry.goals %}
-          <li class="flex items-start"><svg class="w-4 h-4 mr-2 text-green-600 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg><span>{{ g }}</span></li>
-          {% endfor %}
-        </ul>
-      </div>
-      {% endif %}
+        <h5 class="font-semibold mb-2">Planung</h5>
 
-      {% if entry.priorities %}
-      <div class="mt-4">
-        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5-5 5M6 7l5 5-5 5"/></svg>Prioritäten</p>
-        <p id="priorities-{{ entry.id }}" class="mt-1 text-sm"></p>
-      </div>
-      {% endif %}
-
-      {% if entry.strategies %}
-      <div class="mt-4">
-        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2"/></svg>Strategien</p>
-        <div class="flex flex-wrap gap-2 mt-1">
-          {% for s in entry.strategies %}
-          <span class="px-2 py-1 bg-purple-100 text-purple-800 rounded-full text-sm">{{ s }}</span>
-          {% endfor %}
+        {% if entry.goals %}
+        <div>
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 4a1 1 0 011-1h13a1 1 0 01.894 1.447L16.618 8l2.276 4.553A1 1 0 0118 14H4a1 1 0 01-1-1V4z"/></svg>Ziele</p>
+          <ul class="mt-1 space-y-1">
+            {% for g in entry.goals %}
+            <li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>{{ g }}</span></li>
+            {% endfor %}
+          </ul>
         </div>
-      </div>
-      {% endif %}
+        {% endif %}
 
-      {% if entry.resources %}
-      <div class="mt-4">
-        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M5 12l4-4m-4 4l4 4"/></svg>Ressourcen</p>
-        <div class="flex flex-wrap gap-2 mt-1">
-          {% for r in entry.resources %}
-          <span class="px-2 py-1 bg-yellow-100 text-yellow-800 rounded-full text-sm">{{ r }}</span>
-          {% endfor %}
+        {% if entry.priorities %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5-5 5M6 7l5 5-5 5"/></svg>Prioritäten</p>
+          <p id="priorities-{{ entry.id }}" class="mt-1 text-sm"></p>
         </div>
-      </div>
-      {% endif %}
+        {% endif %}
 
-      {% if entry.time_planning %}
-      <div class="mt-4">
-        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3"/></svg>Zeitplanung</p>
-        <ul class="mt-1 space-y-1 text-sm">
-          {% for t in entry.time_planning %}
-          <li class="flex justify-between bg-gray-50 px-2 py-1 rounded"><span>{{ t.goal }}</span><span class="text-gray-600">{{ t.time }}</span></li>
-          {% endfor %}
-        </ul>
-      </div>
-      {% endif %}
+        {% if entry.strategies %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M11 3a1 1 0 00-1 1v2a1 1 0 01-1 1H7a1 1 0 000 2h2a1 1 0 011 1v2a1 1 0 002 0V9a1 1 0 011-1h2a1 1 0 000-2h-2a1 1 0 01-1-1V4a1 1 0 00-1-1z"/></svg>Strategien</p>
+          <div class="flex flex-wrap gap-2 mt-1">
+            {% for s in entry.strategies %}
+            <span class="px-2 py-1 bg-purple-100 text-purple-800 rounded-full text-sm">{{ s }}</span>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
 
-      {% if entry.expectations %}
-      <div class="mt-4">
-        <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7"/></svg>Erwartungen</p>
-        <ul class="mt-1 space-y-1 text-sm">
-          {% for e in entry.expectations %}
-          <li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>{{ e.goal }}{% if e.indicator %}: {{ e.indicator }}{% endif %}</span></li>
-          {% endfor %}
-        </ul>
+        {% if entry.resources %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M5 12l4-4m-4 4l4 4"/></svg>Ressourcen</p>
+          <div class="flex flex-wrap gap-2 mt-1">
+            {% for r in entry.resources %}
+            <span class="px-2 py-1 bg-yellow-100 text-yellow-800 rounded-full text-sm">{{ r }}</span>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+
+        {% if entry.time_planning %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3"/></svg>Zeitplanung</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% for t in entry.time_planning %}
+            <li class="flex justify-between bg-gray-50 px-2 py-1 rounded"><span>{{ t.goal }}</span><span class="text-gray-600">{{ t.time }}</span></li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+
+        {% if entry.expectations %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7"/></svg>Erwartungen</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% for e in entry.expectations %}
+            <li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>{{ e.goal }}{% if e.indicator %}: {{ e.indicator }}{% endif %}</span></li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
       </div>
       {% endif %}
 
@@ -162,47 +168,74 @@
       {% if entry.goal_achievement %}
       <div class="mt-6 border-t pt-4">
         <h5 class="font-semibold mb-2">Reflexion</h5>
-        <p class="font-semibold">Zielerreichung</p>
-        <ul class="mt-1 space-y-1 text-sm">
-          {% for ga in entry.goal_achievement %}
-          <li>{{ ga.goal }}: {{ ga.achievement }}{% if ga.comment %} – {{ ga.comment }}{% endif %}</li>
-          {% endfor %}
-        </ul>
+
+        <div>
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>Zielerreichung</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% for ga in entry.goal_achievement %}
+            <li class="flex items-start"><svg class="w-4 h-4 mr-2 text-green-600 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg><span>{{ ga.goal }}: {{ ga.achievement }}{% if ga.comment %} – {{ ga.comment }}{% endif %}</span></li>
+            {% endfor %}
+          </ul>
+        </div>
+
         {% if entry.strategy_evaluation %}
-        <p class="font-semibold mt-4">Strategie</p>
-        <ul class="mt-1 space-y-1 text-sm">
-          {% for se in entry.strategy_evaluation %}
-          <li>{{ se.strategy }}: {{ se.helpful }}{% if se.reason %} – {{ se.reason }}{% endif %} (erneut: {{ se.reuse }})</li>
-          {% endfor %}
-        </ul>
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M11 3a1 1 0 00-1 1v2a1 1 0 01-1 1H7a1 1 0 000 2h2a1 1 0 011 1v2a1 1 0 002 0V9a1 1 0 011-1h2a1 1 0 000-2h-2a1 1 0 01-1-1V4a1 1 0 00-1-1z"/></svg>Strategie</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% for se in entry.strategy_evaluation %}
+            <li class="flex items-start"><svg class="w-3 h-3 mr-2 text-purple-600 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>{{ se.strategy }}: {{ se.helpful }}{% if se.reason %} – {{ se.reason }}{% endif %} (erneut: {{ se.reuse }})</span></li>
+            {% endfor %}
+          </ul>
+        </div>
         {% endif %}
+
         {% if entry.learned_subject or entry.learned_work %}
-        <p class="font-semibold mt-4">Selbsteinschätzung</p>
-        {% if entry.learned_subject %}<p>Fachlich: {{ entry.learned_subject }}</p>{% endif %}
-        {% if entry.learned_work %}<p>Arbeitsweise: {{ entry.learned_work }}</p>{% endif %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5.121 17.804A13.937 13.937 0 0112 15c2.5 0 4.847.655 6.879 1.804M15 11a3 3 0 10-6 0 3 3 0 006 0z"/></svg>Selbsteinschätzung</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% if entry.learned_subject %}<li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>Fachlich: {{ entry.learned_subject }}</span></li>{% endif %}
+            {% if entry.learned_work %}<li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>Arbeitsweise: {{ entry.learned_work }}</span></li>{% endif %}
+          </ul>
+        </div>
         {% endif %}
+
         {% if entry.planning_realistic or entry.planning_deviations %}
-        <p class="font-semibold mt-4">Zeitmanagement</p>
-        {% if entry.planning_realistic %}<p>Planung realistisch: {{ entry.planning_realistic }}</p>{% endif %}
-        {% if entry.planning_deviations %}<p>Abweichungen: {{ entry.planning_deviations }}</p>{% endif %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3"/></svg>Zeitmanagement</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% if entry.planning_realistic %}<li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>Planung realistisch: {{ entry.planning_realistic }}</span></li>{% endif %}
+            {% if entry.planning_deviations %}<li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>Abweichungen: {{ entry.planning_deviations }}</span></li>{% endif %}
+          </ul>
+        </div>
         {% endif %}
+
         {% if entry.motivation_rating or entry.motivation_improve %}
-        <p class="font-semibold mt-4">Emotionen/Motivation</p>
-        {% if entry.motivation_rating %}<p>Motivation: {{ entry.motivation_rating }}</p>{% endif %}
-        {% if entry.motivation_improve %}<p>Stärken: {{ entry.motivation_improve }}</p>{% endif %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 21l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.18L12 21z"/></svg>Emotionen/Motivation</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% if entry.motivation_rating %}<li class="flex items-start"><svg class="w-3 h-3 mr-2 text-red-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>Motivation: {{ entry.motivation_rating }}</span></li>{% endif %}
+            {% if entry.motivation_improve %}<li class="flex items-start"><svg class="w-3 h-3 mr-2 text-red-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>Stärken: {{ entry.motivation_improve }}</span></li>{% endif %}
+          </ul>
+        </div>
         {% endif %}
+
         {% if entry.next_phase or entry.strategy_outlook %}
-        <p class="font-semibold mt-4">Ausblick</p>
-        {% if entry.next_phase %}<p>Nächste Phase: {{ entry.next_phase }}</p>{% endif %}
-        {% if entry.strategy_outlook %}<p>Strategien: {{ entry.strategy_outlook }}</p>{% endif %}
+        <div class="mt-4">
+          <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>Ausblick</p>
+          <ul class="mt-1 space-y-1 text-sm">
+            {% if entry.next_phase %}<li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>Nächste Phase: {{ entry.next_phase }}</span></li>{% endif %}
+            {% if entry.strategy_outlook %}<li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>Strategien: {{ entry.strategy_outlook }}</span></li>{% endif %}
+          </ul>
+        </div>
         {% endif %}
+
       </div>
       {% endif %}
     </div>
   </div>
 
   <!-- Execution Modal -->
-  <div id="executionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+  <div id="executionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full overflow-y-auto overflow-x-hidden">
     <div class="relative p-4 w-full max-w-2xl max-h-full">
       <div class="relative bg-white rounded-lg shadow modal-content">
         <div class="p-4">
@@ -396,7 +429,7 @@
 </div>
 
 <!-- Planning Modal -->
-<div id="planningModal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+<div id="planningModal" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full overflow-y-auto overflow-x-hidden">
   <div class="relative p-4 w-full max-w-2xl max-h-full">
     <div class="relative bg-white rounded-lg shadow modal-content">
       <div class="p-4">


### PR DESCRIPTION
## Summary
- Center execution and planning modals
- Add planning header with updated icons and clock styling
- Style reflection section with icons and bullet lists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a24d9eac3c8324a0a6a99c9f0264cf