### PR TITLE
Fix student dashboard modal positioning and timeline style

### DIFF
--- a/dashboard/templates/dashboard/base.html
+++ b/dashboard/templates/dashboard/base.html
@@ -19,12 +19,20 @@
         {% block content %}{% endblock %}
     </main>
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-    <script src="https://cdn.jsdelivr.net/npm/flowbite@2.4.1/dist/flowbite.min.js"></script>
     <script>
         document.addEventListener('click', function (e) {
-            const btn = e.target.closest('[data-modal-hide]');
-            if (btn) {
-                const modalId = btn.getAttribute('data-modal-hide');
+            const openBtn = e.target.closest('[data-modal-target]');
+            if (openBtn) {
+                const modalId = openBtn.getAttribute('data-modal-target');
+                const modal = document.getElementById(modalId);
+                if (modal) {
+                    modal.classList.remove('hidden');
+                }
+            }
+
+            const closeBtn = e.target.closest('[data-modal-hide]');
+            if (closeBtn) {
+                const modalId = closeBtn.getAttribute('data-modal-hide');
                 const modal = document.getElementById(modalId);
                 if (modal) {
                     modal.classList.add('hidden');

--- a/dashboard/templates/dashboard/student_dashboard.html
+++ b/dashboard/templates/dashboard/student_dashboard.html
@@ -16,15 +16,7 @@
   }
   .timeline-entry { position: relative; padding-top: 2rem; }
   .timeline-entry::before {
-    content: "";
-    position: absolute;
-    left: 50%;
-    top: 0;
-    transform: translate(-50%, -50%);
-    width: 1rem;
-    height: 1rem;
-    border-radius: 9999px;
-    background: #3b82f6;
+    display: none;
   }
   .timeline-card {
     transition: transform 0.3s, opacity 0.3s, max-width 0.3s;
@@ -79,7 +71,7 @@
     </div>
   </div>
   <div class="timeline-button relative h-16 flex items-center justify-center">
-    <button data-modal-target="planningModal" data-modal-toggle="planningModal" class="text-white px-4 py-2 rounded {% if can_create_entry %}bg-green-500{% else %}bg-gray-400 cursor-not-allowed{% endif %}" {% if not can_create_entry %}disabled{% endif %}>Neues Tagesziel</button>
+    <button data-modal-target="planningModal" class="text-white px-4 py-2 rounded {% if can_create_entry %}bg-green-500{% else %}bg-gray-400 cursor-not-allowed{% endif %}" {% if not can_create_entry %}disabled{% endif %}>Neues Tagesziel</button>
   </div>
   {% endif %}
   {% for entry in entries %}
@@ -102,7 +94,7 @@
             <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="3"/></svg>Ziele</p>
             <ul class="mt-1 space-y-1">
               {% for g in entry.goals %}
-              <li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>{{ g }}</span></li>
+              <li class="flex items-start"><svg class="w-3 h-3 mr-2 text-gray-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>{{ g }}</span></li>
               {% endfor %}
             </ul>
           </div>
@@ -148,7 +140,7 @@
             <p class="font-semibold flex items-center"><svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7"/></svg>Erwartungen</p>
             <ul class="mt-1 space-y-1 text-sm">
               {% for e in entry.expectations %}
-              <li class="flex items-start"><svg class="w-3 h-3 mr-2 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>{{ e.goal }}{% if e.indicator %}: {{ e.indicator }}{% endif %}</span></li>
+              <li class="flex items-start"><svg class="w-3 h-3 mr-2 text-gray-500 flex-shrink-0" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/></svg><span>{{ e.goal }}{% if e.indicator %}: {{ e.indicator }}{% endif %}</span></li>
               {% endfor %}
             </ul>
           </div>
@@ -264,7 +256,7 @@
   </div>
 
   <!-- Execution Modal -->
-  <div id="executionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900 bg-opacity-50">
+  <div id="executionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900 bg-opacity-50 backdrop-blur-sm">
     <div class="relative p-4 w-full max-w-2xl max-h-full">
       <div class="relative bg-white rounded-lg shadow modal-content">
         <div class="p-4">
@@ -323,7 +315,7 @@
   </div>
 
   <!-- Unplanned Activity Modal -->
-  <div id="unplannedModal-{{ entry.id }}" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full bg-black bg-opacity-50">
+  <div id="unplannedModal-{{ entry.id }}" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full bg-gray-900 bg-opacity-50 backdrop-blur-sm">
       <div class="bg-white p-4 rounded shadow w-full max-w-md modal-content">
         <h3 class="text-lg font-semibold mb-4">Ein Ziel mit dem sich beschäftigt wurde, das jedoch nicht geplant war, hinzufügen</h3>
       <input type="text" id="unplanned-input-{{ entry.id }}" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5">
@@ -350,7 +342,7 @@
   {% endwith %}
 
   <!-- Reflection Modal -->
-  <div id="reflectionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 left-0 right-0 z-50 flex justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900 bg-opacity-50">
+  <div id="reflectionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 left-0 right-0 z-50 flex justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900 bg-opacity-50 backdrop-blur-sm">
     <div class="relative w-full max-w-4xl max-h-full">
       <div class="relative bg-white rounded-lg shadow modal-content">
         <div class="p-6">
@@ -464,7 +456,7 @@
 </div>
 
 <!-- Planning Modal -->
-<div id="planningModal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900 bg-opacity-50">
+<div id="planningModal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900 bg-opacity-50 backdrop-blur-sm">
   <div class="relative p-4 w-full max-w-2xl max-h-full">
     <div class="relative bg-white rounded-lg shadow modal-content">
       <div class="p-4">
@@ -528,7 +520,7 @@
 </div>
 
 <!-- Goal Modal -->
-<div id="goalModal" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full bg-black bg-opacity-50">
+<div id="goalModal" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full bg-gray-900 bg-opacity-50 backdrop-blur-sm">
   <div class="bg-white p-4 rounded shadow w-full max-w-md modal-content">
     <h3 class="text-lg font-semibold mb-4">Ein Ziel festlegen</h3>
     <input type="text" id="goal-input" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5">
@@ -539,7 +531,7 @@
 </div>
 
 <!-- Strategy Modal -->
-<div id="strategyModal" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full bg-black bg-opacity-50">
+<div id="strategyModal" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full bg-gray-900 bg-opacity-50 backdrop-blur-sm">
   <div class="bg-white p-4 rounded shadow w-full max-w-md modal-content">
     <h3 class="text-lg font-semibold mb-4">Vorgehen/Strategie hinzufügen</h3>
     <input type="text" id="strategy-input" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5">
@@ -550,7 +542,7 @@
 </div>
 
 <!-- Resource Modal -->
-<div id="resourceModal" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full bg-black bg-opacity-50">
+<div id="resourceModal" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full bg-gray-900 bg-opacity-50 backdrop-blur-sm">
   <div class="bg-white p-4 rounded shadow w-full max-w-md modal-content">
     <h3 class="text-lg font-semibold mb-4">Ressource hinzufügen</h3>
     <input type="text" id="resource-input" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5">


### PR DESCRIPTION
## Summary
- Ensure modals consistently open centered by handling data-modal-target clicks without Flowbite
- Blur and dim modal backgrounds instead of using black overlays
- Remove blue dots from the timeline and neutralize bullet colors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2baf6c4748324b25ff41283573218