### PR TITLE
Add teacher student export view

### DIFF
--- a/dashboard/export_views.py
+++ b/dashboard/export_views.py
@@ -1,8 +1,243 @@
+import csv
+import json
+
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.utils.text import slugify
+
+from openpyxl import Workbook
+
+from .models import Classroom, Student
 
 
 @login_required
 def export_classroom_data(request, classroom_id):
     """Placeholder view for exporting classroom data."""
     return HttpResponse("Export interface not implemented yet.")
+
+
+def _entry_nested(entry):
+    def _tp(lst):
+        return [{"Ziel": item.get("goal"), "Zeit": item.get("time")} for item in lst]
+
+    def _exp(lst):
+        return [
+            {"Ziel": item.get("goal"), "Indikator": item.get("indicator")} for item in lst
+        ]
+
+    def _tu(lst):
+        return [{"Ziel": item.get("goal"), "Zeit": item.get("time")} for item in lst]
+
+    def _sc(lst):
+        return [
+            {
+                "Strategie": item.get("strategy"),
+                "Genutzt": item.get("used"),
+                "Sinnvoll": item.get("useful"),
+                "Anpassung": item.get("adaptation"),
+            }
+            for item in lst
+        ]
+
+    def _ga(lst):
+        return [
+            {
+                "Ziel": item.get("goal"),
+                "Ergebnis": item.get("achievement"),
+                "Kommentar": item.get("comment"),
+            }
+            for item in lst
+        ]
+
+    return {
+        "Datum": str(entry.session_date),
+        "Planung": {
+            "Ziele": entry.goals,
+            "Prioritäten": entry.priorities,
+            "Strategien": entry.strategies,
+            "Ressourcen": entry.resources,
+            "Zeitplanung": _tp(entry.time_planning),
+            "Erwartungen": _exp(entry.expectations),
+        },
+        "Durchführung": {
+            "Schritte": entry.steps,
+            "Zeitnutzung": _tu(entry.time_usage),
+            "Strategie-Check": _sc(entry.strategy_check),
+            "Probleme": entry.problems,
+            "Emotionen": entry.emotions,
+        },
+        "Reflexion": {
+            "Zielerreichung": _ga(entry.goal_achievement),
+            "Strategie-Bewertung": entry.strategy_evaluation,
+            "Gelerntes (Inhaltlich)": entry.learned_subject,
+            "Gelerntes (Arbeitsweise)": entry.learned_work,
+            "War die Planung realistisch?": entry.planning_realistic,
+            "Abweichungen von der Planung": entry.planning_deviations,
+            "Motivation (Bewertung)": entry.motivation_rating,
+            "Motivation verbessern": entry.motivation_improve,
+            "Nächste Lernphase": entry.next_phase,
+            "Strategie-Ausblick": entry.strategy_outlook,
+        },
+    }
+
+
+def _entry_flat(entry):
+    def _join(lst):
+        return "; ".join(lst) if lst else ""
+
+    def _tp(lst):
+        return "; ".join(
+            f"{item.get('goal')} ({item.get('time')})" for item in lst
+        )
+
+    def _exp(lst):
+        return "; ".join(
+            f"{item.get('goal')}{': ' + item.get('indicator') if item.get('indicator') else ''}"
+            for item in lst
+        )
+
+    def _sc(lst):
+        parts = []
+        for item in lst:
+            txt = item.get("strategy", "")
+            if item.get("used") is not None:
+                txt += f" – {'genutzt' if item['used'] else 'nicht genutzt'}"
+            if item.get("useful") is not None:
+                txt += f", {'sinnvoll' if item['useful'] else 'nicht sinnvoll'}"
+            if item.get("adaptation"):
+                txt += f" – {item['adaptation']}"
+            parts.append(txt)
+        return "; ".join(parts)
+
+    def _ga(lst):
+        return "; ".join(
+            f"{item.get('goal')}: {item.get('achievement')}{' – ' + item.get('comment') if item.get('comment') else ''}"
+            for item in lst
+        )
+
+    return {
+        "Datum": str(entry.session_date),
+        "Ziele": _join(entry.goals),
+        "Prioritäten": _join(entry.priorities),
+        "Strategien": _join(entry.strategies),
+        "Ressourcen": _join(entry.resources),
+        "Zeitplanung": _tp(entry.time_planning),
+        "Erwartungen": _exp(entry.expectations),
+        "Schritte": _join(entry.steps),
+        "Zeitnutzung": _tp(entry.time_usage),
+        "Strategie-Check": _sc(entry.strategy_check),
+        "Probleme": entry.problems,
+        "Emotionen": entry.emotions,
+        "Zielerreichung": _ga(entry.goal_achievement),
+        "Strategie-Bewertung": _join(entry.strategy_evaluation),
+        "Gelerntes (Inhaltlich)": entry.learned_subject,
+        "Gelerntes (Arbeitsweise)": entry.learned_work,
+        "War die Planung realistisch?": entry.planning_realistic,
+        "Abweichungen von der Planung": entry.planning_deviations,
+        "Motivation (Bewertung)": entry.motivation_rating,
+        "Motivation verbessern": entry.motivation_improve,
+        "Nächste Lernphase": entry.next_phase,
+        "Strategie-Ausblick": entry.strategy_outlook,
+    }
+
+
+@login_required
+def export_student_data(request, classroom_id, student_id):
+    classroom = get_object_or_404(Classroom, id=classroom_id, teacher=request.user)
+    student = get_object_or_404(Student, id=student_id, classroom=classroom)
+    fmt = request.GET.get("format", "json").lower()
+    group_label = (
+        "Kontrollgruppe"
+        if classroom.group_type == Classroom.GroupType.CONTROL
+        else "Experimentalgruppe"
+    )
+    entries = student.entries.order_by("session_date")
+
+    if fmt == "json":
+        data = {
+            "Pseudonym": student.pseudonym,
+            "Gruppenzugehörigkeit": group_label,
+            "Gesamtziel": student.overall_goal,
+            "Fälligkeitsdatum des Gesamtziels": student.overall_goal_due_date.isoformat()
+            if student.overall_goal_due_date
+            else None,
+            "Einträge": [_entry_nested(e) for e in entries],
+        }
+        response = HttpResponse(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            content_type="application/json",
+        )
+        response["Content-Disposition"] = (
+            f"attachment; filename={slugify(student.pseudonym)}.json"
+        )
+        return response
+
+    fieldnames = [
+        "Pseudonym",
+        "Gruppenzugehörigkeit",
+        "Gesamtziel",
+        "Fälligkeitsdatum des Gesamtziels",
+        "Datum",
+        "Ziele",
+        "Prioritäten",
+        "Strategien",
+        "Ressourcen",
+        "Zeitplanung",
+        "Erwartungen",
+        "Schritte",
+        "Zeitnutzung",
+        "Strategie-Check",
+        "Probleme",
+        "Emotionen",
+        "Zielerreichung",
+        "Strategie-Bewertung",
+        "Gelerntes (Inhaltlich)",
+        "Gelerntes (Arbeitsweise)",
+        "War die Planung realistisch?",
+        "Abweichungen von der Planung",
+        "Motivation (Bewertung)",
+        "Motivation verbessern",
+        "Nächste Lernphase",
+        "Strategie-Ausblick",
+    ]
+
+    rows = []
+    for e in entries:
+        row = {
+            "Pseudonym": student.pseudonym,
+            "Gruppenzugehörigkeit": group_label,
+            "Gesamtziel": student.overall_goal or "",
+            "Fälligkeitsdatum des Gesamtziels": student.overall_goal_due_date or "",
+        }
+        row.update(_entry_flat(e))
+        rows.append(row)
+
+    if fmt == "csv":
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = (
+            f"attachment; filename={slugify(student.pseudonym)}.csv"
+        )
+        writer = csv.DictWriter(response, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+        return response
+
+    if fmt == "xlsx":
+        wb = Workbook()
+        ws = wb.active
+        ws.append(fieldnames)
+        for row in rows:
+            ws.append([row.get(fn, "") for fn in fieldnames])
+        response = HttpResponse(
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        response["Content-Disposition"] = (
+            f"attachment; filename={slugify(student.pseudonym)}.xlsx"
+        )
+        wb.save(response)
+        return response
+
+    return HttpResponse(status=400)
+

--- a/dashboard/templates/dashboard/student_detail.html
+++ b/dashboard/templates/dashboard/student_detail.html
@@ -1,6 +1,78 @@
 {% extends "dashboard/base.html" %}
 {% block content %}
 <h1 class="text-2xl mb-4">Schüler: {{ student.pseudonym }}</h1>
-<p>Detailansicht folgt.</p>
-<a href="{% url 'classroom_list' %}" class="text-blue-600 hover:underline">Zurück zur Übersicht</a>
+<p class="mb-2">Gruppe: {{ student.classroom.get_group_type_display }}</p>
+{% if student.overall_goal %}
+<p class="mb-4"><strong>Gesamtziel bis {{ student.overall_goal_due_date }}:</strong> {{ student.overall_goal }}</p>
+{% endif %}
+
+<div class="space-y-6">
+  {% for entry in entries %}
+  <div class="border p-4 rounded">
+    <h2 class="font-semibold mb-2">{{ entry.session_date }}</h2>
+    {% if entry.goals %}<p><strong>Ziele:</strong> {{ entry.goals|join:", " }}</p>{% endif %}
+    {% if entry.priorities %}<p><strong>Prioritäten:</strong> {{ entry.priorities|join:", " }}</p>{% endif %}
+    {% if entry.strategies %}<p><strong>Strategien:</strong> {{ entry.strategies|join:", " }}</p>{% endif %}
+    {% if entry.resources %}<p><strong>Ressourcen:</strong> {{ entry.resources|join:", " }}</p>{% endif %}
+    {% if entry.time_planning %}
+    <p><strong>Zeitplanung:</strong>
+      {% for tp in entry.time_planning %}
+        {{ tp.goal }} ({{ tp.time }}){% if not forloop.last %}; {% endif %}
+      {% endfor %}
+    </p>
+    {% endif %}
+    {% if entry.expectations %}
+    <p><strong>Erwartungen:</strong>
+      {% for exp in entry.expectations %}
+        {{ exp.goal }}{% if exp.indicator %}: {{ exp.indicator }}{% endif %}{% if not forloop.last %}; {% endif %}
+      {% endfor %}
+    </p>
+    {% endif %}
+    {% if entry.steps %}<p><strong>Schritte:</strong> {{ entry.steps|join:", " }}</p>{% endif %}
+    {% if entry.time_usage %}
+    <p><strong>Zeitnutzung:</strong>
+      {% for tu in entry.time_usage %}
+        {{ tu.goal }} ({{ tu.time }}){% if not forloop.last %}; {% endif %}
+      {% endfor %}
+    </p>
+    {% endif %}
+    {% if entry.strategy_check %}
+    <p><strong>Strategie-Check:</strong>
+      {% for sc in entry.strategy_check %}
+        {{ sc.strategy }}{% if sc.used is not None %} – {{ sc.used|yesno:'genutzt,nicht genutzt' }}{% endif %}{% if sc.useful is not None %}, {{ sc.useful|yesno:'sinnvoll,nicht sinnvoll' }}{% endif %}{% if sc.adaptation %} – {{ sc.adaptation }}{% endif %}{% if not forloop.last %}; {% endif %}
+      {% endfor %}
+    </p>
+    {% endif %}
+    {% if entry.problems %}<p><strong>Probleme:</strong> {{ entry.problems }}</p>{% endif %}
+    {% if entry.emotions %}<p><strong>Emotionen:</strong> {{ entry.emotions }}</p>{% endif %}
+    {% if entry.goal_achievement %}
+    <p><strong>Zielerreichung:</strong>
+      {% for ga in entry.goal_achievement %}
+        {{ ga.goal }}: {{ ga.achievement }}{% if ga.comment %} – {{ ga.comment }}{% endif %}{% if not forloop.last %}; {% endif %}
+      {% endfor %}
+    </p>
+    {% endif %}
+    {% if entry.strategy_evaluation %}<p><strong>Strategie-Bewertung:</strong> {{ entry.strategy_evaluation|join:", " }}</p>{% endif %}
+    {% if entry.learned_subject %}<p><strong>Gelerntes (Inhaltlich):</strong> {{ entry.learned_subject }}</p>{% endif %}
+    {% if entry.learned_work %}<p><strong>Gelerntes (Arbeitsweise):</strong> {{ entry.learned_work }}</p>{% endif %}
+    {% if entry.planning_realistic %}<p><strong>War die Planung realistisch?</strong> {{ entry.planning_realistic }}</p>{% endif %}
+    {% if entry.planning_deviations %}<p><strong>Abweichungen von der Planung:</strong> {{ entry.planning_deviations }}</p>{% endif %}
+    {% if entry.motivation_rating %}<p><strong>Motivation (Bewertung):</strong> {{ entry.motivation_rating }}</p>{% endif %}
+    {% if entry.motivation_improve %}<p><strong>Motivation verbessern:</strong> {{ entry.motivation_improve }}</p>{% endif %}
+    {% if entry.next_phase %}<p><strong>Nächste Lernphase:</strong> {{ entry.next_phase }}</p>{% endif %}
+    {% if entry.strategy_outlook %}<p><strong>Strategie-Ausblick:</strong> {{ entry.strategy_outlook }}</p>{% endif %}
+  </div>
+  {% empty %}
+  <p>Keine Einträge vorhanden.</p>
+  {% endfor %}
+</div>
+
+<div class="mt-4 space-x-4">
+  <a href="{% url 'student_export' classroom_id=student.classroom.id student_id=student.id %}?format=json" class="text-blue-600 hover:underline">Export als JSON</a>
+  <a href="{% url 'student_export' classroom_id=student.classroom.id student_id=student.id %}?format=csv" class="text-blue-600 hover:underline">Export als CSV</a>
+  <a href="{% url 'student_export' classroom_id=student.classroom.id student_id=student.id %}?format=xlsx" class="text-blue-600 hover:underline">Export als XLSX</a>
+</div>
+
+<a href="{% url 'classroom_list' %}" class="text-blue-600 hover:underline mt-4 inline-block">Zurück zur Übersicht</a>
 {% endblock %}
+

--- a/dashboard/tests/test_student_export.py
+++ b/dashboard/tests/test_student_export.py
@@ -1,0 +1,65 @@
+import json
+
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+from dashboard.models import Classroom, Student, SRLEntry
+
+
+@pytest.mark.django_db
+def test_student_detail_shows_entries(client):
+    user = User.objects.create_user(username="t1", password="pass")
+    classroom = Classroom.objects.create(teacher=user, name="Klasse A", group_type="CONTROL")
+    student = Student.objects.create(classroom=classroom, pseudonym="S1")
+    SRLEntry.objects.create(student=student, goals=["Testziel"])
+    client.login(username="t1", password="pass")
+    response = client.get(reverse("student_detail", args=[classroom.id, student.id]))
+    assert response.status_code == 200
+    assert b"Testziel" in response.content
+
+
+@pytest.mark.django_db
+def test_student_export_json(client):
+    user = User.objects.create_user(username="t1", password="pass")
+    classroom = Classroom.objects.create(teacher=user, name="Klasse A", group_type="EXPERIMENTAL")
+    student = Student.objects.create(classroom=classroom, pseudonym="S1")
+    SRLEntry.objects.create(student=student, session_date="2024-01-01", goals=["Z1"])
+    client.login(username="t1", password="pass")
+    url = reverse("student_export", args=[classroom.id, student.id])
+    response = client.get(url + "?format=json")
+    assert response.status_code == 200
+    data = json.loads(response.content.decode("utf-8"))
+    assert data["Pseudonym"] == "S1"
+    assert data["Gruppenzugehörigkeit"] == "Experimentalgruppe"
+    assert data["Einträge"][0]["Planung"]["Ziele"] == ["Z1"]
+
+
+@pytest.mark.django_db
+def test_student_export_csv(client):
+    user = User.objects.create_user(username="t1", password="pass")
+    classroom = Classroom.objects.create(teacher=user, name="Klasse A", group_type="CONTROL")
+    student = Student.objects.create(classroom=classroom, pseudonym="S1")
+    SRLEntry.objects.create(student=student, session_date="2024-01-01", goals=["Z1"])
+    client.login(username="t1", password="pass")
+    url = reverse("student_export", args=[classroom.id, student.id])
+    response = client.get(url + "?format=csv")
+    assert response.status_code == 200
+    assert "text/csv" in response["Content-Type"]
+    assert "Z1" in response.content.decode("utf-8")
+
+
+@pytest.mark.django_db
+def test_student_export_xlsx(client):
+    user = User.objects.create_user(username="t1", password="pass")
+    classroom = Classroom.objects.create(teacher=user, name="Klasse A", group_type="CONTROL")
+    student = Student.objects.create(classroom=classroom, pseudonym="S1")
+    SRLEntry.objects.create(student=student, session_date="2024-01-01", goals=["Z1"])
+    client.login(username="t1", password="pass")
+    url = reverse("student_export", args=[classroom.id, student.id])
+    response = client.get(url + "?format=xlsx")
+    assert response.status_code == 200
+    assert (
+        response["Content-Type"]
+        == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -26,6 +26,11 @@ urlpatterns = [
         name="student_detail",
     ),
     path(
+        "classrooms/<int:classroom_id>/students/<int:student_id>/export/",
+        export_views.export_student_data,
+        name="student_export",
+    ),
+    path(
         "classrooms/<int:classroom_id>/overall-goal/",
         views.set_class_overall_goal,
         name="class_overall_goal",

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -199,7 +199,12 @@ def student_reset_password(request, classroom_id, student_id):
 def student_detail(request, classroom_id, student_id):
     classroom = get_object_or_404(Classroom, id=classroom_id, teacher=request.user)
     student = get_object_or_404(Student, id=student_id, classroom=classroom)
-    return render(request, "dashboard/student_detail.html", {"student": student})
+    entries = student.entries.order_by("-session_date")
+    return render(
+        request,
+        "dashboard/student_detail.html",
+        {"student": student, "entries": entries},
+    )
 
 
 def validate_openai_key(key: str) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django~=4.2.23
 pytest-django==4.11.1
 requests
+openpyxl


### PR DESCRIPTION
## Summary
- show full student diary details in teacher view with simple layout
- allow exporting individual student data as JSON, CSV or XLSX with descriptive field names
- add tests for student detail view and export formats

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2d7fbbaa08324ab1244a894bdc0a2