### PR TITLE
Improve experimental dashboard chat flow and prompts

### DIFF
--- a/dashboard/templates/dashboard/experimental_student_dashboard.html
+++ b/dashboard/templates/dashboard/experimental_student_dashboard.html
@@ -270,7 +270,7 @@
     <form onsubmit="submitChat(event,'planning')">
       <input id="planning-input" class="border w-full p-2" placeholder="Antwort..." autocomplete="off" />
       <div class="mt-2 flex justify-end">
-        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Senden</button>
+        <button id="planning-send" type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Senden</button>
         <button type="button" class="ml-2 bg-gray-300 px-4 py-2 rounded" onclick="closeChat('planning')">Schließen</button>
       </div>
     </form>
@@ -283,7 +283,7 @@
     <form onsubmit="submitChat(event,'execution')">
       <input id="execution-input" class="border w-full p-2" placeholder="Antwort..." autocomplete="off" />
       <div class="mt-2 flex justify-end">
-        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Senden</button>
+        <button id="execution-send" type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Senden</button>
         <button type="button" class="ml-2 bg-gray-300 px-4 py-2 rounded" onclick="closeChat('execution')">Schließen</button>
       </div>
     </form>
@@ -296,14 +296,88 @@
     <form onsubmit="submitChat(event,'reflection')">
       <input id="reflection-input" class="border w-full p-2" placeholder="Antwort..." autocomplete="off" />
       <div class="mt-2 flex justify-end">
-        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Senden</button>
+        <button id="reflection-send" type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Senden</button>
         <button type="button" class="ml-2 bg-gray-300 px-4 py-2 rounded" onclick="closeChat('reflection')">Schließen</button>
       </div>
     </form>
   </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/ScrollTrigger.min.js"></script>
 <script>
+document.addEventListener('DOMContentLoaded', function() {
+  if (window.gsap) {
+    const entries = gsap
+      .utils
+      .toArray('.timeline-entry')
+      .filter(e => !e.classList.contains('overall-goal'));
+    const overallGoal = document.querySelector('.timeline-entry.overall-goal');
+    let activeEntry = overallGoal || entries[0] || null;
+    if (activeEntry) {
+      setActive(activeEntry);
+    }
+
+    function setActive(entry) {
+      document.querySelectorAll('.timeline-card').forEach(card => {
+        card.classList.remove('active');
+        card.classList.add('inactive');
+        const activeView = card.querySelector('.active-view');
+        const inactiveView = card.querySelector('.inactive-view');
+        if (activeView && inactiveView) {
+          activeView.classList.add('hidden');
+          inactiveView.classList.remove('hidden');
+        }
+        gsap.to(card, { scale: 0.9, opacity: 0.4, duration: 0.3 });
+      });
+      const card = entry.querySelector('.timeline-card');
+      card.classList.add('active');
+      card.classList.remove('inactive');
+      const activeView = card.querySelector('.active-view');
+      const inactiveView = card.querySelector('.inactive-view');
+      if (activeView && inactiveView) {
+        inactiveView.classList.add('hidden');
+        activeView.classList.remove('hidden');
+        gsap.fromTo(activeView, { opacity: 0 }, { opacity: 1, duration: 0.3 });
+      }
+      gsap.to(card, { scale: 1, opacity: 1, duration: 0.3 });
+    }
+
+    function updateActive() {
+      if (overallGoal && window.scrollY <= 5) {
+        if (activeEntry !== overallGoal) {
+          activeEntry = overallGoal;
+          setActive(activeEntry);
+        }
+        return;
+      }
+
+      const viewportCenter = window.innerHeight / 2;
+      let closest = activeEntry && activeEntry !== overallGoal ? activeEntry : entries[0];
+      let closestDist = closest
+        ? Math.abs(closest.getBoundingClientRect().top + closest.getBoundingClientRect().height / 2 - viewportCenter)
+        : Infinity;
+      entries.forEach(entry => {
+        const rect = entry.getBoundingClientRect();
+        const entryCenter = rect.top + rect.height / 2;
+        const dist = Math.abs(entryCenter - viewportCenter);
+        if (dist < closestDist - 20) {
+          closestDist = dist;
+          closest = entry;
+        }
+      });
+      if (closest && closest !== activeEntry) {
+        activeEntry = closest;
+        setActive(activeEntry);
+      }
+    }
+
+    window.addEventListener('scroll', () => requestAnimationFrame(updateActive));
+
+    gsap.from('.timeline-entry', { opacity: 0, y: 50, duration: 0.6, stagger: 0.2 });
+  }
+});
+
 let currentEntryId = null;
 const chatHistory = {planning: [], execution: [], reflection: []};
 
@@ -350,6 +424,14 @@ function submitChat(event, type) {
 }
 
 function sendMessage(type, message) {
+  const input = document.getElementById(type + '-input');
+  const sendBtn = document.getElementById(type + '-send');
+  if (input) input.disabled = true;
+  if (sendBtn) {
+    sendBtn.disabled = true;
+    sendBtn.dataset.orig = sendBtn.innerHTML;
+    sendBtn.innerHTML = '<span class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin inline-block"></span>';
+  }
   if (message) chatHistory[type].push({role: 'user', content: message});
   const url = type === 'planning'
     ? urls.planning
@@ -372,13 +454,28 @@ function sendMessage(type, message) {
       chatHistory[type].push({role: 'assistant', content: data.reply});
       if (data.entry_id !== undefined) {
         currentEntryId = data.entry_id;
+        if (type === 'planning') {
+          closeChat('planning');
+          window.location.reload();
+          return;
+        }
       }
     }
     renderChat(type);
+    if (input) input.disabled = false;
+    if (sendBtn) {
+      sendBtn.disabled = false;
+      sendBtn.innerHTML = sendBtn.dataset.orig;
+    }
   })
   .catch(() => {
     chatHistory[type].push({role: 'assistant', content: '(Netzwerkfehler – bitte erneut senden)'});
     renderChat(type);
+    if (input) input.disabled = false;
+    if (sendBtn) {
+      sendBtn.disabled = false;
+      sendBtn.innerHTML = sendBtn.dataset.orig;
+    }
   });
 }
 
@@ -386,10 +483,17 @@ function renderChat(type) {
   const log = document.getElementById(type + '-log');
   log.innerHTML = '';
   chatHistory[type].forEach(msg => {
-    const div = document.createElement('div');
-    div.className = msg.role === 'assistant' ? 'text-blue-700 mb-2' : 'text-gray-800 mb-2 text-right';
-    div.textContent = msg.content;
-    log.appendChild(div);
+    const wrap = document.createElement('div');
+    wrap.className = 'mb-2 flex ' + (msg.role === 'assistant' ? 'justify-start' : 'justify-end');
+    const bubble = document.createElement('div');
+    bubble.className = msg.role === 'assistant'
+      ? 'bg-gray-100 text-gray-900 rounded-xl px-3 py-2 max-w-[80%]'
+      : 'bg-blue-600 text-white rounded-xl px-3 py-2 max-w-[80%]';
+    bubble.style.whiteSpace = 'pre-wrap';
+    bubble.style.lineHeight = '1.4';
+    bubble.textContent = msg.content;
+    wrap.appendChild(bubble);
+    log.appendChild(wrap);
   });
   log.scrollTop = log.scrollHeight;
 }


### PR DESCRIPTION
## Summary
- Stop planning chat after successful save and reload dashboard
- Add loading state and bubble styling to chat messages
- Tighten backend prompts, limit tokens, and handle rate limits
- Animate experimental dashboard timeline entries to focus new items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c5997c4c83249b4152bcbd45c744