### PR TITLE
Redirect root URL to student dashboard

### DIFF
--- a/EduNav/urls.py
+++ b/EduNav/urls.py
@@ -15,10 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import RedirectView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("dashboard/", include("dashboard.urls")),
     path("student/", include("dashboard.student_urls")),
+    path("", RedirectView.as_view(url="/student/dashboard/", permanent=False)),
     path("", include("django.contrib.auth.urls")),
 ]

--- a/dashboard/tests/test_root_redirect.py
+++ b/dashboard/tests/test_root_redirect.py
@@ -1,0 +1,8 @@
+import pytest
+
+@pytest.mark.django_db
+def test_root_redirects_to_student_dashboard(client):
+    response = client.get("/")
+    assert response.status_code == 302
+    assert response.url == "/student/dashboard/"
+


### PR DESCRIPTION
## Summary
- Redirect `/` to `/student/dashboard/`
- Add test ensuring root path redirects to student dashboard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c4db4f788324977b36b5a3dfe386