### PR TITLE
Add planning feedback workflow for experimental students

### DIFF
--- a/dashboard/student_urls.py
+++ b/dashboard/student_urls.py
@@ -29,4 +29,14 @@ urlpatterns = [
         student_views.add_reflection_json,
         name="student_entry_reflection_json",
     ),
+    path(
+        "api/planning/feedback/",
+        student_views.planning_feedback,
+        name="planning_feedback",
+    ),
+    path(
+        "api/planning/feedback/reset/",
+        student_views.reset_planning_feedback,
+        name="planning_feedback_reset",
+    ),
 ]

--- a/dashboard/templates/dashboard/experimental_student_dashboard.html
+++ b/dashboard/templates/dashboard/experimental_student_dashboard.html
@@ -71,7 +71,7 @@
     </div>
   </div>
   <div class="timeline-button relative h-16 flex items-center justify-center">
-    <button onclick="openChat('planning')" class="text-white px-4 py-2 rounded {% if can_create_entry %}bg-green-500{% else %}bg-gray-400 cursor-not-allowed{% endif %}" {% if not can_create_entry %}disabled{% endif %}>Neues Tagesziel</button>
+    <button data-modal-target="planningModal" class="text-white px-4 py-2 rounded {% if can_create_entry %}bg-green-500{% else %}bg-gray-400 cursor-not-allowed{% endif %}" {% if not can_create_entry %}disabled{% endif %}>Neues Tagesziel</button>
   </div>
   {% endif %}
   {% for entry in entries %}
@@ -177,14 +177,14 @@
             {% if entry.emotions %}<p class="mt-2"><span class="font-semibold">Emotionen:</span> {{ entry.emotions }}</p>{% else %}<p class="text-red-500 text-sm mt-2">Emotionen fehlen</p>{% endif %}
             {% if not entry.goal_achievement %}
             <div class="mt-4 text-center">
-              <button onclick="openChat('execution', {{ entry.id }})" class="bg-blue-500 text-white px-3 py-1 rounded">Aktualisieren</button>
+              <button data-modal-target="executionModal-{{ entry.id }}" onclick="setupExecutionModal({{ entry.id }})" class="bg-blue-500 text-white px-3 py-1 rounded">Aktualisieren</button>
             </div>
             {% endif %}
           </div>
           {% else %}
           {% if not entry.goal_achievement %}
           <div class="flex justify-center">
-            <button onclick="openChat('execution', {{ entry.id }})" class="w-24 h-24 rounded-full bg-blue-500 text-white text-sm flex items-center justify-center text-center">Durchführung<br>protokollieren</button>
+            <button data-modal-target="executionModal-{{ entry.id }}" onclick="setupExecutionModal({{ entry.id }})" class="w-24 h-24 rounded-full bg-blue-500 text-white text-sm flex items-center justify-center text-center">Durchführung<br>protokollieren</button>
           </div>
           {% endif %}
           {% endif %}
@@ -243,7 +243,7 @@
           {% else %}
           <div class="flex flex-col items-center">
             {% if entry.steps and entry.time_usage and entry.emotions %}
-            <button onclick="openChat('reflection', {{ entry.id }})" class="w-24 h-24 rounded-full bg-red-500 text-white text-sm flex items-center justify-center text-center">Reflexion<br>starten</button>
+            <button onclick="finalizeExecution({{ entry.id }})" class="w-24 h-24 rounded-full bg-red-500 text-white text-sm flex items-center justify-center text-center">Reflexion<br>starten</button>
             {% else %}
             <button disabled class="w-24 h-24 rounded-full bg-gray-300 text-gray-600 text-sm flex items-center justify-center text-center cursor-not-allowed">Reflexion<br>starten</button>
             <p class="mt-2 text-xs text-gray-500 text-center">Reflexion erst nach der Durchführung möglich</p>
@@ -255,41 +255,1049 @@
     </div>
   </div>
 
-{% endfor %}
+  <!-- Execution Modal -->
+  <div id="executionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+    <div class="relative p-4 w-full max-w-2xl max-h-full">
+      <div class="relative bg-white rounded-lg shadow modal-content">
+        <div class="p-4">
+          <h3 class="text-lg font-semibold mb-4">Durchführung</h3>
+          <form method="post" action="{% url 'student_entry_execution' entry.id %}" id="execution-form-{{ entry.id }}" class="modal-form">
+            {% csrf_token %}
+            <input type="hidden" name="steps" id="steps-{{ entry.id }}">
+            <input type="hidden" name="time_usage" id="time-usage-{{ entry.id }}">
+            <input type="hidden" name="strategy_check" id="strategy-check-{{ entry.id }}">
 
+            <div class="section">
+              <label class="block mb-2">Was mache ich konkret?</label>
+              <div id="steps-list-{{ entry.id }}" class="space-y-2"></div>
+              <button type="button" id="add-unplanned-{{ entry.id }}" class="mt-2 bg-gray-200 px-2 py-1 rounded">ungeplante Beschäftigungen hinzufügen</button>
+              <p class="text-sm text-gray-500 mt-1">Hake an, womit du dich gerade beschäftigst (nicht abgeschlossen).</p>
+            </div>
+
+            <div class="section">
+              <label class="block mb-2">Wie viel Zeit brauche ich tatsächlich?</label>
+              <div id="time-usage-list-{{ entry.id }}" class="space-y-2"></div>
+            </div>
+
+            <div class="section">
+              <label class="block mb-2">Welche Strategien setze ich tatsächlich ein? Sind diese Strategien auch in der Praxis sinnvoll? Muss ich meine Strategien anpassen?</label>
+              <table class="w-full text-left border" id="strategy-check-table-{{ entry.id }}">
+                <thead>
+                  <tr>
+                    <th class="border px-2 py-1">Strategie</th>
+                    <th class="border px-2 py-1">nutze ich diese?</th>
+                    <th class="border px-2 py-1">Halte ich diese auch in der Praxis noch für sinnvoll?</th>
+                    <th class="border px-2 py-1">ggf. Änderungen/Anpassungen der Strategie an die Praxis</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+
+            <div class="section">
+              <label class="block mb-2">Gibt es Hindernisse? Passe ich meinen Plan an – wenn ja, wie?</label>
+              <textarea name="problems" id="problems-{{ entry.id }}" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5" rows="2"></textarea>
+            </div>
+
+            <div class="section">
+              <label class="block mb-2">Wie fühle ich mich (z. B. motiviert, blockiert, zufrieden)? Was unterstützt / stört meine Konzentration?</label>
+              <textarea name="emotions" id="emotions-{{ entry.id }}" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5" rows="2"></textarea>
+            </div>
+
+            <div class="flex justify-end space-x-2 mt-4">
+              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">Speichern</button>
+              <button type="button" data-modal-hide="executionModal-{{ entry.id }}" class="bg-red-500 text-white px-4 py-2 rounded">Abbrechen</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Unplanned Activity Modal -->
+  <div id="unplannedModal-{{ entry.id }}" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full">
+      <div class="bg-white p-4 rounded shadow w-full max-w-md modal-content">
+        <h3 class="text-lg font-semibold mb-4">Ein Ziel mit dem sich beschäftigt wurde, das jedoch nicht geplant war, hinzufügen</h3>
+      <input type="text" id="unplanned-input-{{ entry.id }}" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5">
+      <div class="mt-4 text-right">
+        <button type="button" id="unplanned-save-{{ entry.id }}" class="bg-blue-500 text-white px-4 py-2 rounded">Speichern</button>
+      </div>
+    </div>
+  </div>
+
+  {% with eid=entry.id|stringformat:'s' %}
+    {% with gid='goals-data-'|add:eid tid='time-data-'|add:eid sid='strategies-data-'|add:eid pr='priorities-data-'|add:eid sd='steps-data-'|add:eid tu='time-usage-data-'|add:eid sc='strategy-check-data-'|add:eid pd='problems-data-'|add:eid ed='emotions-data-'|add:eid ga='goal-achievement-data-'|add:eid se='strategy-evaluation-data-'|add:eid %}
+        {{ entry.goals|json_script:gid }}
+        {{ entry.time_planning|json_script:tid }}
+        {{ entry.strategies|json_script:sid }}
+        {{ entry.priorities|json_script:pr }}
+        {{ entry.steps|json_script:sd }}
+        {{ entry.time_usage|json_script:tu }}
+        {{ entry.strategy_check|json_script:sc }}
+        {{ entry.problems|json_script:pd }}
+        {{ entry.emotions|json_script:ed }}
+        {{ entry.goal_achievement|json_script:ga }}
+        {{ entry.strategy_evaluation|json_script:se }}
+    {% endwith %}
+  {% endwith %}
+
+  <!-- Reflection Modal -->
+  <div id="reflectionModal-{{ entry.id }}" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 left-0 right-0 z-50 flex justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
+    <div class="relative w-full max-w-4xl max-h-full">
+      <div class="relative bg-white rounded-lg shadow modal-content">
+        <div class="p-6">
+          <h3 class="text-lg font-semibold mb-4">Reflexion</h3>
+          <form method="post" action="{% url 'student_entry_reflection' entry.id %}" id="reflection-form-{{ entry.id }}" class="modal-form">
+            {% csrf_token %}
+            <input type="hidden" name="goal_achievement" id="goal-achievement-{{ entry.id }}">
+            <input type="hidden" name="strategy_evaluation" id="strategy-evaluation-{{ entry.id }}">
+            <div class="section">
+              <h4 class="font-semibold mb-2">Habe ich meine Ziele erreicht? (vollständig / teilweise / nicht)</h4>
+              <table class="w-full text-left border" id="goal-achievement-table-{{ entry.id }}">
+                <thead>
+                  <tr>
+                    <th class="border px-2 py-1">Ziel</th>
+                    <th class="border px-2 py-1">Erreichung</th>
+                    <th class="border px-2 py-1">Was hat dazu beigetragen oder mich gehindert?</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+
+            <div class="section">
+              <h4 class="font-semibold mb-2">Bewertung: Strategien/Vorgehensweisen</h4>
+              <table class="w-full text-left border" id="strategy-evaluation-table-{{ entry.id }}">
+                <thead>
+                  <tr>
+                    <th class="border px-2 py-1">Strategie</th>
+                    <th class="border px-2 py-1">Hat dir diese Strategie rückblickend geholfen?</th>
+                    <th class="border px-2 py-1">Warum (kurze Begründung)?</th>
+                    <th class="border px-2 py-1">Würdest du sie erneut nutzen?</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+
+            <div class="section">
+              <h4 class="font-semibold mb-2">Selbsteinschätzung</h4>
+              <div class="mb-4">
+                <label class="block mb-2">Was habe ich fachlich gelernt?</label>
+                {% with field_id="learned-subject-"|add:entry.id %}
+                  {{ reflection_form.learned_subject|add_id:field_id }}
+                {% endwith %}
+              </div>
+              <div class="mb-4">
+                <label class="block mb-2">Was habe ich über meine Arbeitsweise gelernt?</label>
+                {% with field_id="learned-work-"|add:entry.id %}
+                  {{ reflection_form.learned_work|add_id:field_id }}
+                {% endwith %}
+              </div>
+            </div>
+
+            <div class="section">
+              <h4 class="font-semibold mb-2">Zeitmanagement</h4>
+              <div class="mb-4">
+                <label class="block mb-2">War meine Planung realistisch?</label>
+                {% with field_id="planning-realistic-"|add:entry.id %}
+                  {{ reflection_form.planning_realistic|add_id:field_id }}
+                {% endwith %}
+              </div>
+              <div class="mb-4">
+                <label class="block mb-2">Wo gab es Abweichungen?</label>
+                {% with field_id="planning-deviations-"|add:entry.id %}
+                  {{ reflection_form.planning_deviations|add_id:field_id }}
+                {% endwith %}
+              </div>
+            </div>
+
+            <div class="section">
+              <h4 class="font-semibold mb-2">Emotionen/Motivation</h4>
+              <div class="mb-4">
+                <label class="block mb-2">Wie bewerte ich meine Motivation über die Zeit hinweg?</label>
+                {% with field_id="motivation-rating-"|add:entry.id %}
+                  {{ reflection_form.motivation_rating|add_id:field_id }}
+                {% endwith %}
+              </div>
+              <div class="mb-4">
+                <label class="block mb-2">Was könnte ich tun, um sie zu stärken?</label>
+                {% with field_id="motivation-improve-"|add:entry.id %}
+                  {{ reflection_form.motivation_improve|add_id:field_id }}
+                {% endwith %}
+              </div>
+            </div>
+
+            <div class="section">
+              <h4 class="font-semibold mb-2">Ausblick</h4>
+              <div class="mb-4">
+                <label class="block mb-2">Was nehme ich mir für die nächste Phase konkret vor?</label>
+                {% with field_id="next-phase-"|add:entry.id %}
+                  {{ reflection_form.next_phase|add_id:field_id }}
+                {% endwith %}
+              </div>
+              <div class="mb-4">
+                <label class="block mb-2">Welche Strategien will ich beibehalten oder ändern?</label>
+                {% with field_id="strategy-outlook-"|add:entry.id %}
+                  {{ reflection_form.strategy_outlook|add_id:field_id }}
+                {% endwith %}
+              </div>
+            </div>
+
+            <div class="flex justify-end space-x-2 mt-4">
+              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">Speichern</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
 </div>
 
-<!-- Chat placeholders for experimental group -->
-<div id="planning-chat" class="hidden fixed top-0 left-0 right-0 z-50 flex justify-center items-center w-full h-full bg-gray-900 bg-opacity-50">
-  <div class="bg-white p-4 rounded shadow w-full max-w-2xl">
-    <p>Chat placeholder for planning (coming soon).</p>
-    <button class="mt-4 bg-blue-500 text-white px-4 py-2 rounded" onclick="closeChat('planning')">Schließen</button>
+<!-- Planning Modal -->
+<div id="planningModal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+  <div class="relative p-4 w-full max-w-2xl max-h-full">
+    <div class="relative bg-white rounded-lg shadow modal-content">
+      <div class="p-4">
+        <h3 class="text-lg font-semibold mb-4">Tagesplanung</h3>
+        <form method="post" action="{% url 'student_entry_create' %}" id="planning-form" class="modal-form">
+          {% csrf_token %}
+          {{ planning_form.goals }}
+          {{ planning_form.priorities }}
+          {{ planning_form.strategies }}
+          {{ planning_form.resources }}
+          {{ planning_form.time_planning }}
+          {{ planning_form.expectations }}
+
+          <div class="section">
+            <label class="block mb-2">Ziele: Was will ich heute / diese Woche erreichen? (fachliche Ziele, Teilaufgaben, persönliche Lernziele)</label>
+            <div id="goals-list" class="flex flex-wrap gap-2"></div>
+            <button type="button" id="add-goal" class="mt-2 bg-gray-200 px-2 py-1 rounded">Ziel hinzufügen</button>
+          </div>
+
+          <div class="section">
+            <label class="block mb-2">Prioritäten: Welche Aufgaben sind am wichtigsten?</label>
+            <div id="priority-list" class="flex flex-col gap-2"></div>
+            <p class="text-sm text-gray-500 mt-2">Klicke die besonders wichtigen Ziele an und ordne sie entsprechend in der Reihenfolge in der du sie bearbeiten willst an</p>
+          </div>
+
+          <div class="section">
+            <label class="block mb-2">Vorgehen/Strategien: Wie will ich vorgehen? (z. B. Recherche, Entwürfe, Austausch, Versuch & Irrtum)</label>
+            <div id="strategy-list" class="flex flex-wrap gap-2"></div>
+            <button type="button" id="add-strategy" class="mt-2 bg-gray-200 px-2 py-1 rounded">Vorgehen/Strategien hinzufügen</button>
+          </div>
+
+          <div class="section">
+            <label class="block mb-2">Ressourcen: Welche Materialien, Werkzeuge, Personen brauche ich?</label>
+            <div id="resource-list" class="flex flex-wrap gap-2"></div>
+            <button type="button" id="add-resource" class="mt-2 bg-gray-200 px-2 py-1 rounded">Ressource hinzufügen</button>
+          </div>
+
+          <div class="section">
+            <label class="block mb-2">Zeitplanung: Wie lange möchte ich für welche Aufgabe arbeiten?</label>
+            <div id="time-planning-list" class="space-y-2"></div>
+          </div>
+
+          <div class="section">
+            <label class="block mb-2">Erwartungen: Woran merke ich am Ende, dass ich erfolgreich war?</label>
+            <table class="w-full text-left border" id="expectations-table">
+              <thead>
+                <tr><th class="border px-2 py-1">Ziel</th><th class="border px-2 py-1">Indikatoren... Woran messe ich den Erfolg?</th></tr>
+              </thead>
+              <tbody id="expectations-body"></tbody>
+            </table>
+          </div>
+
+          <div id="ai-feedback" class="hidden mb-4 p-2 border rounded bg-gray-50 text-sm"></div>
+
+          <div class="flex justify-end space-x-2 mt-4">
+            <button type="button" id="get-feedback" class="bg-blue-500 text-white px-4 py-2 rounded">Feedback erhalten</button>
+            <button type="submit" id="planning-save" class="bg-green-500 text-white px-4 py-2 rounded" disabled>Speichern</button>
+            <button type="button" data-modal-hide="planningModal" class="bg-red-500 text-white px-4 py-2 rounded">Abbrechen</button>
+          </div>
+        </form>
+      </div>
+    </div>
   </div>
 </div>
 
-<div id="execution-chat" class="hidden fixed top-0 left-0 right-0 z-50 flex justify-center items-center w-full h-full bg-gray-900 bg-opacity-50">
-  <div class="bg-white p-4 rounded shadow w-full max-w-2xl">
-    <p>Chat placeholder for execution (coming soon).</p>
-    <button class="mt-4 bg-blue-500 text-white px-4 py-2 rounded" onclick="closeChat('execution')">Schließen</button>
+<!-- Goal Modal -->
+<div id="goalModal" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full">
+  <div class="bg-white p-4 rounded shadow w-full max-w-md modal-content">
+    <h3 class="text-lg font-semibold mb-4">Ein Ziel festlegen</h3>
+    <input type="text" id="goal-input" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5">
+    <div class="mt-4 text-right">
+      <button type="button" id="goal-save" class="bg-blue-500 text-white px-4 py-2 rounded">Speichern</button>
+    </div>
   </div>
 </div>
 
-<div id="reflection-chat" class="hidden fixed top-0 left-0 right-0 z-50 flex justify-center items-center w-full h-full bg-gray-900 bg-opacity-50">
-  <div class="bg-white p-4 rounded shadow w-full max-w-2xl">
-    <p>Chat placeholder for reflection (coming soon).</p>
-    <button class="mt-4 bg-blue-500 text-white px-4 py-2 rounded" onclick="closeChat('reflection')">Schließen</button>
+<!-- Strategy Modal -->
+<div id="strategyModal" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full">
+  <div class="bg-white p-4 rounded shadow w-full max-w-md modal-content">
+    <h3 class="text-lg font-semibold mb-4">Vorgehen/Strategie hinzufügen</h3>
+    <input type="text" id="strategy-input" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5">
+    <div class="mt-4 text-right">
+      <button type="button" id="strategy-save" class="bg-blue-500 text-white px-4 py-2 rounded">Speichern</button>
+    </div>
   </div>
 </div>
 
+<!-- Resource Modal -->
+<div id="resourceModal" class="hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-center w-full h-full">
+  <div class="bg-white p-4 rounded shadow w-full max-w-md modal-content">
+    <h3 class="text-lg font-semibold mb-4">Ressource hinzufügen</h3>
+    <input type="text" id="resource-input" class="block w-full rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 p-2.5">
+    <div class="mt-4 text-right">
+      <button type="button" id="resource-save" class="bg-blue-500 text-white px-4 py-2 rounded">Speichern</button>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/ScrollTrigger.min.js"></script>
 <script>
-let currentEntryId = null;
-function openChat(type, entryId=null) {
-  currentEntryId = entryId;
-  document.getElementById(type + '-chat').classList.remove('hidden');
+const MAX_MINUTES = {{ student.classroom.max_planning_execution_minutes }};
+function parseData(elId) {
+  const el = document.getElementById(elId);
+  if (!el) return null;
+  try {
+    let data = JSON.parse(el.textContent);
+    if (typeof data === 'string') {
+      try { data = JSON.parse(data); } catch {}
+    }
+    return data;
+  } catch {
+    return null;
+  }
 }
-function closeChat(type) {
-  document.getElementById(type + '-chat').classList.add('hidden');
+
+function toMinutes(str) {
+  const parts = (str || '0:0').split(':');
+  return parseInt(parts[0] || '0') * 60 + parseInt(parts[1] || '0');
 }
+
+function getCookie(name) {
+  let cookieValue = null;
+  if (document.cookie && document.cookie !== '') {
+    const cookies = document.cookie.split(';');
+    for (let i = 0; i < cookies.length; i++) {
+      const cookie = cookies[i].trim();
+      if (cookie.substring(0, name.length + 1) === (name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+}
+
+function setupExecutionModal(id) {
+  const form = document.getElementById('execution-form-' + id);
+  if (form.dataset.initialized) return;
+
+  const goals = parseData('goals-data-' + id) || [];
+  const timePlanning = parseData('time-data-' + id) || [];
+  const strategies = parseData('strategies-data-' + id) || [];
+  const savedSteps = parseData('steps-data-' + id) || [];
+  const savedTimeUsage = parseData('time-usage-data-' + id) || [];
+  const savedStrategyCheck = parseData('strategy-check-data-' + id) || [];
+  const savedProblems = parseData('problems-data-' + id) || '';
+  const savedEmotions = parseData('emotions-data-' + id) || '';
+
+  const stepsInput = document.getElementById('steps-' + id);
+  const timeInput = document.getElementById('time-usage-' + id);
+  const strategyInput = document.getElementById('strategy-check-' + id);
+  const stepsList = document.getElementById('steps-list-' + id);
+  const timeList = document.getElementById('time-usage-list-' + id);
+  const strategyBody = document.querySelector('#strategy-check-table-' + id + ' tbody');
+  const problemsField = document.getElementById('problems-' + id);
+  const emotionsField = document.getElementById('emotions-' + id);
+
+  const checked = [...savedSteps];
+  const unplanned = savedSteps.filter(g => !goals.includes(g));
+  const timeMap = {};
+  savedTimeUsage.forEach(t => { timeMap[t.goal] = t.time; });
+  const strategyData = strategies.map(s => {
+    const found = savedStrategyCheck.find(sc => sc.strategy === s) || {};
+    return {strategy: s, used: !!found.used, useful: !!found.useful, adaptation: found.adaptation || ''};
+  });
+
+  function updateHidden() {
+    stepsInput.value = JSON.stringify(checked);
+    const tData = checked.map(g => ({goal: g, time: timeMap[g] || (timePlanning.find(p => p.goal === g)?.time || '00:00')}));
+    timeInput.value = JSON.stringify(tData);
+    strategyInput.value = JSON.stringify(strategyData);
+  }
+
+  function renderSteps() {
+    stepsList.innerHTML = '';
+    const all = goals.concat(unplanned);
+    all.forEach(g => {
+      const div = document.createElement('div');
+      div.className = 'flex items-center gap-2';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.checked = checked.includes(g);
+      cb.addEventListener('change', () => {
+        if (cb.checked) {
+          checked.push(g);
+        } else {
+          const i = checked.indexOf(g);
+          if (i > -1) checked.splice(i, 1);
+        }
+        renderTime();
+        updateHidden();
+      });
+      const span = document.createElement('span');
+      span.textContent = g;
+      div.appendChild(cb);
+      div.appendChild(span);
+      stepsList.appendChild(div);
+    });
+  }
+
+  function renderTime() {
+    timeList.innerHTML = '';
+    const all = goals.concat(unplanned);
+    all.forEach(g => {
+      const wrap = document.createElement('div');
+      wrap.className = 'flex items-center gap-2';
+      const label = document.createElement('span');
+      label.className = 'flex-1';
+      label.textContent = g;
+      const input = document.createElement('input');
+      input.type = 'time';
+      input.className = 'border rounded p-1';
+      let val = timeMap[g] || (timePlanning.find(p => p.goal === g)?.time || '00:00');
+      if (!checked.includes(g)) {
+        input.value = '00:00';
+        input.disabled = true;
+        input.classList.add('bg-gray-200');
+      } else {
+        input.value = val;
+      }
+      input.addEventListener('change', e => { timeMap[g] = e.target.value; updateHidden(); });
+      wrap.appendChild(label);
+      wrap.appendChild(input);
+      timeList.appendChild(wrap);
+    });
+  }
+
+  function renderStrategies() {
+    strategyBody.innerHTML = '';
+    strategyData.forEach(item => {
+      const tr = document.createElement('tr');
+      const tdS = document.createElement('td');
+      tdS.className = 'border px-2 py-1';
+      tdS.textContent = item.strategy;
+
+      const tdU = document.createElement('td');
+      tdU.className = 'border px-2 py-1 text-center';
+      const cbU = document.createElement('input');
+      cbU.type = 'checkbox';
+      cbU.checked = item.used;
+      cbU.addEventListener('change', () => { item.used = cbU.checked; updateHidden(); });
+      tdU.appendChild(cbU);
+
+      const tdF = document.createElement('td');
+      tdF.className = 'border px-2 py-1 text-center';
+      const cbF = document.createElement('input');
+      cbF.type = 'checkbox';
+      cbF.checked = item.useful;
+      cbF.addEventListener('change', () => { item.useful = cbF.checked; updateHidden(); });
+      tdF.appendChild(cbF);
+
+      const tdA = document.createElement('td');
+      tdA.className = 'border px-2 py-1';
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.className = 'w-full border rounded p-1';
+      inp.value = item.adaptation;
+      inp.addEventListener('input', e => { item.adaptation = e.target.value; updateHidden(); });
+      tdA.appendChild(inp);
+
+      tr.appendChild(tdS);
+      tr.appendChild(tdU);
+      tr.appendChild(tdF);
+      tr.appendChild(tdA);
+      strategyBody.appendChild(tr);
+    });
+  }
+
+  const addBtn = document.getElementById('add-unplanned-' + id);
+  const modal = document.getElementById('unplannedModal-' + id);
+  const modalInput = document.getElementById('unplanned-input-' + id);
+  const modalSave = document.getElementById('unplanned-save-' + id);
+
+  addBtn.addEventListener('click', () => { modal.classList.remove('hidden'); });
+  modalSave.addEventListener('click', () => {
+    const val = modalInput.value.trim();
+    if (val) {
+      unplanned.push(val);
+      checked.push(val);
+      modalInput.value = '';
+      modal.classList.add('hidden');
+      renderSteps();
+      renderTime();
+      updateHidden();
+    }
+  });
+
+  form.addEventListener('submit', (e) => {
+    updateHidden();
+    const usage = JSON.parse(timeInput.value || '[]');
+    const usageMinutes = usage.reduce((sum, t) => sum + toMinutes(t.time), 0);
+    if (usageMinutes > MAX_MINUTES) {
+      e.preventDefault();
+      alert(`Die Gesamtzeit darf ${MAX_MINUTES} Minuten nicht überschreiten.`);
+    }
+  });
+
+  renderSteps();
+  renderTime();
+  renderStrategies();
+  problemsField.value = savedProblems;
+  emotionsField.value = savedEmotions;
+  updateHidden();
+  form.dataset.initialized = '1';
+}
+
+function setupReflectionModal(id) {
+  const modal = document.getElementById('reflectionModal-' + id);
+  if (modal.dataset.initialized) return;
+
+  const goals = parseData('goals-data-' + id) || [];
+  const steps = parseData('steps-data-' + id) || [];
+  const strategies = parseData('strategies-data-' + id) || [];
+  const savedGA = parseData('goal-achievement-data-' + id) || [];
+  const savedSE = parseData('strategy-evaluation-data-' + id) || [];
+
+  const gaInput = document.getElementById('goal-achievement-' + id);
+  const seInput = document.getElementById('strategy-evaluation-' + id);
+  const gaBody = document.querySelector('#goal-achievement-table-' + id + ' tbody');
+  const seBody = document.querySelector('#strategy-evaluation-table-' + id + ' tbody');
+
+  const unplanned = steps.filter(g => !goals.includes(g));
+  const allGoals = goals.concat(unplanned);
+
+  const gaData = allGoals.map(g => {
+    const found = savedGA.find(item => item.goal === g) || {};
+    return {
+      goal: g,
+      unplanned: unplanned.includes(g),
+      achievement: found.achievement || '',
+      comment: found.comment || ''
+    };
+  });
+
+  const seData = strategies.map(s => {
+    const found = savedSE.find(item => item.strategy === s) || {};
+    return {
+      strategy: s,
+      helpful: found.helpful || '',
+      reason: found.reason || '',
+      reuse: found.reuse || ''
+    };
+  });
+
+  function updateHidden() {
+    gaInput.value = JSON.stringify(gaData);
+    seInput.value = JSON.stringify(seData);
+  }
+
+  function renderGoals() {
+    gaBody.innerHTML = '';
+    gaData.forEach((item, i) => {
+      const tr = document.createElement('tr');
+      const tdG = document.createElement('td');
+      tdG.className = 'border px-2 py-1';
+      tdG.textContent = item.goal + (item.unplanned ? ' (ungeplant)' : '');
+      const tdA = document.createElement('td');
+      tdA.className = 'border px-2 py-1 text-center';
+      ['vollständig','teilweise','nicht'].forEach(val => {
+        const label = document.createElement('label');
+        label.className = 'mr-2';
+        const radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.name = 'ga-' + id + '-' + i;
+        radio.value = val;
+        radio.required = true;
+        if (item.achievement === val) radio.checked = true;
+        radio.addEventListener('change', () => { item.achievement = val; updateHidden(); });
+        label.appendChild(radio);
+        label.appendChild(document.createTextNode(val));
+        tdA.appendChild(label);
+      });
+      const tdC = document.createElement('td');
+      tdC.className = 'border px-2 py-1';
+      const ta = document.createElement('textarea');
+      ta.className = 'w-full border rounded p-1';
+      ta.rows = 1;
+      ta.required = true;
+      ta.value = item.comment;
+      ta.addEventListener('input', e => { item.comment = e.target.value; updateHidden(); });
+      tdC.appendChild(ta);
+      tr.appendChild(tdG);
+      tr.appendChild(tdA);
+      tr.appendChild(tdC);
+      gaBody.appendChild(tr);
+    });
+  }
+
+  function renderStrategies() {
+    seBody.innerHTML = '';
+    seData.forEach((item, i) => {
+      const tr = document.createElement('tr');
+      const tdS = document.createElement('td');
+      tdS.className = 'border px-2 py-1';
+      tdS.textContent = item.strategy;
+      const tdH = document.createElement('td');
+      tdH.className = 'border px-2 py-1 text-center';
+      ['ja','teilweise','nein'].forEach(val => {
+        const label = document.createElement('label');
+        label.className = 'mr-2';
+        const radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.name = 'se-help-' + id + '-' + i;
+        radio.value = val;
+        radio.required = true;
+        if (item.helpful === val) radio.checked = true;
+        radio.addEventListener('change', () => { item.helpful = val; updateHidden(); });
+        label.appendChild(radio);
+        label.appendChild(document.createTextNode(val));
+        tdH.appendChild(label);
+      });
+      const tdR = document.createElement('td');
+      tdR.className = 'border px-2 py-1';
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.className = 'w-full border rounded p-1';
+      inp.value = item.reason;
+      inp.addEventListener('input', e => { item.reason = e.target.value; updateHidden(); });
+      tdR.appendChild(inp);
+      const tdU = document.createElement('td');
+      tdU.className = 'border px-2 py-1 text-center';
+      ['ja','nein','vielleicht'].forEach(val => {
+        const label = document.createElement('label');
+        label.className = 'mr-2';
+        const radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.name = 'se-reuse-' + id + '-' + i;
+        radio.value = val;
+        radio.required = true;
+        if (item.reuse === val) radio.checked = true;
+        radio.addEventListener('change', () => { item.reuse = val; updateHidden(); });
+        label.appendChild(radio);
+        label.appendChild(document.createTextNode(val));
+        tdU.appendChild(label);
+      });
+      tr.appendChild(tdS);
+      tr.appendChild(tdH);
+      tr.appendChild(tdR);
+      tr.appendChild(tdU);
+      seBody.appendChild(tr);
+    });
+  }
+
+  renderGoals();
+  renderStrategies();
+  updateHidden();
+  modal.dataset.initialized = '1';
+}
+
+function finalizeExecution(id) {
+  const steps = parseData('steps-data-' + id) || [];
+  const timeUsage = parseData('time-usage-data-' + id) || [];
+  const emotions = parseData('emotions-data-' + id) || '';
+  const missing = [];
+  steps.forEach(g => {
+    const t = timeUsage.find(tu => tu.goal === g)?.time || '00:00';
+    if (!t || t === '00:00') missing.push('Zeit für "' + g + '"');
+  });
+  if (!emotions || !emotions.trim()) missing.push('Gefühle/Konzentration');
+  if (missing.length) {
+    alert('Folgende Angaben fehlen noch:\n' + missing.join('\n'));
+  } else {
+    if (confirm('Wenn du fortfährst, kannst du die Durchführung nicht mehr ändern. Bist du sicher?')) {
+      const modal = document.getElementById('reflectionModal-' + id);
+      if (modal) {
+        setupReflectionModal(id);
+        modal.classList.remove('hidden');
+      }
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  const goals = [];
+  const priorities = [];
+  const strategies = [];
+  const resources = [];
+  const timePlanning = [];
+  const expectations = [];
+
+  const goalsList = document.getElementById('goals-list');
+  const priorityList = document.getElementById('priority-list');
+  const strategyList = document.getElementById('strategy-list');
+  const resourceList = document.getElementById('resource-list');
+  const timePlanningList = document.getElementById('time-planning-list');
+  const expectationsBody = document.getElementById('expectations-body');
+  const saveBtn = document.getElementById('planning-save');
+  const feedbackBtn = document.getElementById('get-feedback');
+  const feedbackBox = document.getElementById('ai-feedback');
+
+  function getPlanningData() {
+    return {
+      goals: goals,
+      priorities: priorities,
+      strategies: strategies,
+      resources: resources,
+      time_planning: timePlanning,
+      expectations: expectations,
+    };
+  }
+
+  function resetFeedback() {
+    feedbackBox.textContent = '';
+    feedbackBox.classList.add('hidden');
+    saveBtn.disabled = true;
+    feedbackBtn.textContent = 'Feedback erhalten';
+    fetch("{% url 'planning_feedback_reset' %}", {
+      method: 'POST',
+      headers: { 'X-CSRFToken': getCookie('csrftoken') }
+    });
+  }
+  resetFeedback();
+
+  document.querySelectorAll('[data-modal-target="planningModal"]').forEach(btn => {
+    btn.addEventListener('click', resetFeedback);
+  });
+
+  // GSAP animations for timeline and modals
+  if (window.gsap) {
+    const entries = gsap
+      .utils
+      .toArray('.timeline-entry')
+      .filter(e => !e.classList.contains('overall-goal'));
+    const overallGoal = document.querySelector('.timeline-entry.overall-goal');
+    let activeEntry = overallGoal || entries[0] || null;
+    if (activeEntry) {
+      setActive(activeEntry);
+    }
+
+    function setActive(entry) {
+      document.querySelectorAll('.timeline-card').forEach(card => {
+        card.classList.remove('active');
+        card.classList.add('inactive');
+        const activeView = card.querySelector('.active-view');
+        const inactiveView = card.querySelector('.inactive-view');
+        if (activeView && inactiveView) {
+          activeView.classList.add('hidden');
+          inactiveView.classList.remove('hidden');
+        }
+        gsap.to(card, { scale: 0.9, opacity: 0.4, duration: 0.3 });
+      });
+      const card = entry.querySelector('.timeline-card');
+      card.classList.add('active');
+      card.classList.remove('inactive');
+      const activeView = card.querySelector('.active-view');
+      const inactiveView = card.querySelector('.inactive-view');
+      if (activeView && inactiveView) {
+        inactiveView.classList.add('hidden');
+        activeView.classList.remove('hidden');
+        gsap.fromTo(activeView, { opacity: 0 }, { opacity: 1, duration: 0.3 });
+      }
+      gsap.to(card, { scale: 1, opacity: 1, duration: 0.3 });
+    }
+
+    function updateActive() {
+      if (overallGoal && window.scrollY <= 5) {
+        if (activeEntry !== overallGoal) {
+          activeEntry = overallGoal;
+          setActive(activeEntry);
+        }
+        return;
+      }
+
+      const viewportCenter = window.innerHeight / 2;
+      let closest = activeEntry && activeEntry !== overallGoal ? activeEntry : entries[0];
+      let closestDist = closest
+        ? Math.abs(closest.getBoundingClientRect().top + closest.getBoundingClientRect().height / 2 - viewportCenter)
+        : Infinity;
+      entries.forEach(entry => {
+        const rect = entry.getBoundingClientRect();
+        const entryCenter = rect.top + rect.height / 2;
+        const dist = Math.abs(entryCenter - viewportCenter);
+        if (dist < closestDist - 20) {
+          closestDist = dist;
+          closest = entry;
+        }
+      });
+      if (closest && closest !== activeEntry) {
+        activeEntry = closest;
+        setActive(activeEntry);
+      }
+    }
+
+    window.addEventListener('scroll', () => requestAnimationFrame(updateActive));
+
+    gsap.from('.timeline-entry', { opacity: 0, y: 50, duration: 0.6, stagger: 0.2 });
+
+    document.querySelectorAll('[data-modal-target]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const modal = document.getElementById(btn.getAttribute('data-modal-target'));
+        modal.classList.toggle('hidden');
+        if (!modal.classList.contains('hidden')) {
+          gsap.fromTo(
+            modal.querySelector('.modal-content'),
+            { y: -20, scale: 0.8, opacity: 0 },
+            { y: 0, scale: 1, opacity: 1, duration: 0.4, ease: 'power2.out' }
+          );
+        }
+      });
+    });
+  }
+
+  function updateHidden() {
+    document.getElementById('id_goals').value = JSON.stringify(goals);
+    document.getElementById('id_priorities').value = JSON.stringify(priorities);
+    document.getElementById('id_strategies').value = JSON.stringify(strategies);
+    document.getElementById('id_resources').value = JSON.stringify(resources);
+    document.getElementById('id_time_planning').value = JSON.stringify(timePlanning);
+    document.getElementById('id_expectations').value = JSON.stringify(expectations);
+  }
+
+  function renderGoals() {
+    goalsList.innerHTML = '';
+    goals.forEach((goal, idx) => {
+      const tag = document.createElement('span');
+      tag.className = 'bg-blue-100 text-blue-800 px-2 py-1 rounded-full flex items-center';
+      tag.textContent = goal;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ml-2 text-red-500';
+      btn.textContent = '×';
+      btn.addEventListener('click', () => removeGoal(idx));
+      tag.appendChild(btn);
+      goalsList.appendChild(tag);
+    });
+    renderPriorities();
+    renderTimePlanning();
+    renderExpectations();
+    updateHidden();
+  }
+
+  function addGoal(goal) {
+    goals.push(goal);
+    priorities.push({goal: goal, priority: false});
+    timePlanning.push({goal: goal, time: '00:00'});
+    expectations.push({goal: goal, indicator: ''});
+    renderGoals();
+  }
+
+  function removeGoal(index) {
+    const goal = goals[index];
+    goals.splice(index,1);
+    const pIndex = priorities.findIndex(p => p.goal === goal);
+    if(pIndex>-1) priorities.splice(pIndex,1);
+    const tIndex = timePlanning.findIndex(p => p.goal === goal);
+    if(tIndex>-1) timePlanning.splice(tIndex,1);
+    const eIndex = expectations.findIndex(p => p.goal === goal);
+    if(eIndex>-1) expectations.splice(eIndex,1);
+    renderGoals();
+  }
+
+  function renderPriorities() {
+    priorityList.innerHTML='';
+    priorities.forEach((item, idx) => {
+      const div = document.createElement('div');
+      div.className = 'px-2 py-1 rounded border cursor-move ' + (item.priority ? 'bg-yellow-200' : 'bg-gray-100');
+      div.textContent = item.goal;
+      div.addEventListener('click', () => {
+        item.priority = !item.priority;
+        renderPriorities();
+      });
+      priorityList.appendChild(div);
+    });
+    if (window.Sortable && !priorityList._sortable) {
+      window.Sortable.create(priorityList, {
+        animation:150,
+        onEnd: function(evt){
+          const moved = priorities.splice(evt.oldIndex,1)[0];
+          priorities.splice(evt.newIndex,0,moved);
+          updateHidden();
+        }
+      });
+      priorityList._sortable = true;
+    }
+    updateHidden();
+  }
+
+  function renderTimePlanning() {
+    timePlanningList.innerHTML='';
+    timePlanning.forEach(item => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'flex items-center gap-2';
+      const label = document.createElement('span');
+      label.className = 'flex-1';
+      label.textContent = item.goal;
+      const input = document.createElement('input');
+      input.type = 'time';
+      input.value = item.time;
+      input.className = 'border rounded p-1';
+      input.addEventListener('change', (e) => { item.time = e.target.value; updateHidden(); });
+      wrapper.appendChild(label);
+      wrapper.appendChild(input);
+      timePlanningList.appendChild(wrapper);
+    });
+    updateHidden();
+  }
+
+  function renderExpectations() {
+    expectationsBody.innerHTML='';
+    expectations.forEach(item => {
+      const tr = document.createElement('tr');
+      const tdGoal = document.createElement('td');
+      tdGoal.className = 'border px-2 py-1';
+      tdGoal.textContent = item.goal;
+      const tdInd = document.createElement('td');
+      tdInd.className = 'border px-2 py-1';
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.className = 'w-full border rounded p-1';
+      input.value = item.indicator;
+      input.addEventListener('input', (e)=>{ item.indicator = e.target.value; updateHidden(); });
+      tdInd.appendChild(input);
+      tr.appendChild(tdGoal);
+      tr.appendChild(tdInd);
+      expectationsBody.appendChild(tr);
+    });
+    updateHidden();
+  }
+
+  function renderStrategies() {
+    strategyList.innerHTML='';
+    strategies.forEach((s, idx)=>{
+      const tag=document.createElement('span');
+      tag.className='bg-blue-100 text-blue-800 px-2 py-1 rounded-full flex items-center';
+      tag.textContent=s;
+      const btn=document.createElement('button');
+      btn.type='button';
+      btn.className='ml-2 text-red-500';
+      btn.textContent='×';
+      btn.addEventListener('click',()=>{strategies.splice(idx,1); renderStrategies(); updateHidden();});
+      tag.appendChild(btn);
+      strategyList.appendChild(tag);
+    });
+    updateHidden();
+  }
+
+  function renderResources() {
+    resourceList.innerHTML='';
+    resources.forEach((s, idx)=>{
+      const tag=document.createElement('span');
+      tag.className='bg-blue-100 text-blue-800 px-2 py-1 rounded-full flex items-center';
+      tag.textContent=s;
+      const btn=document.createElement('button');
+      btn.type='button';
+      btn.className='ml-2 text-red-500';
+      btn.textContent='×';
+      btn.addEventListener('click',()=>{resources.splice(idx,1); renderResources(); updateHidden();});
+      tag.appendChild(btn);
+      resourceList.appendChild(tag);
+    });
+    updateHidden();
+  }
+
+  document.getElementById('add-goal').addEventListener('click', () => {
+    document.getElementById('goalModal').classList.remove('hidden');
+  });
+  document.getElementById('goal-save').addEventListener('click', () => {
+    const val = document.getElementById('goal-input').value.trim();
+    if(val){ addGoal(val); }
+    document.getElementById('goal-input').value='';
+    document.getElementById('goalModal').classList.add('hidden');
+  });
+
+  document.getElementById('add-strategy').addEventListener('click', () => {
+    document.getElementById('strategyModal').classList.remove('hidden');
+  });
+  document.getElementById('strategy-save').addEventListener('click', () => {
+    const val = document.getElementById('strategy-input').value.trim();
+    if(val){ strategies.push(val); renderStrategies(); }
+    document.getElementById('strategy-input').value='';
+    document.getElementById('strategyModal').classList.add('hidden');
+  });
+
+  document.getElementById('add-resource').addEventListener('click', () => {
+    document.getElementById('resourceModal').classList.remove('hidden');
+  });
+  document.getElementById('resource-save').addEventListener('click', () => {
+    const val = document.getElementById('resource-input').value.trim();
+    if(val){ resources.push(val); renderResources(); }
+    document.getElementById('resource-input').value='';
+    document.getElementById('resourceModal').classList.add('hidden');
+  });
+
+  feedbackBtn.addEventListener('click', async () => {
+    updateHidden();
+    try {
+      const response = await fetch("{% url 'planning_feedback' %}", {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCookie('csrftoken'),
+        },
+        body: JSON.stringify({ planning: getPlanningData() })
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        alert(err.error || 'Fehler beim Abrufen des Feedbacks.');
+        return;
+      }
+      const data = await response.json();
+      feedbackBox.textContent = data.feedback;
+      feedbackBox.classList.remove('hidden');
+      saveBtn.disabled = false;
+      feedbackBtn.textContent = 'Feedback aktualisieren';
+    } catch (e) {
+      alert('Fehler beim Abrufen des Feedbacks.');
+    }
+  });
+
+  document.getElementById('planning-form').addEventListener('submit', (e) => {
+    updateHidden();
+    const missing = [];
+    if (!goals.length) missing.push('Mindestens ein Ziel');
+    if (!priorities.some(p => p.priority)) missing.push('Mindestens eine Priorität');
+    if (!strategies.length) missing.push('Mindestens eine Strategie');
+    if (!resources.length) missing.push('Mindestens eine Ressource');
+    if (timePlanning.some(t => !t.time || t.time === '00:00')) missing.push('Zeitplanung für jedes Ziel');
+    if (expectations.some(e => !e.indicator || !e.indicator.trim())) missing.push('Indikator bei Erwartungen');
+    const totalTime = timePlanning.reduce((sum, t) => sum + toMinutes(t.time), 0);
+    if (totalTime > MAX_MINUTES) {
+      e.preventDefault();
+      alert(`Die Gesamtzeit darf ${MAX_MINUTES} Minuten nicht überschreiten.`);
+      return;
+    }
+    if (missing.length) {
+      e.preventDefault();
+      alert('Folgende Angaben fehlen noch:\n' + missing.join('\n'));
+    }
+  });
+
+  document.querySelectorAll('[id^="priorities-"]').forEach(el => {
+    const id = el.id.split('-')[1];
+    const data = parseData('priorities-data-' + id) || [];
+    if (data.length) {
+      el.innerHTML = data.map(p => p.priority ? '<span class="underline">' + p.goal + '</span>' : p.goal).join(' &rarr; ');
+    }
+  });
+
+});
 </script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- align experimental dashboard with control layout
- add AI feedback request before saving planning
- provide API endpoints for generating and resetting planning feedback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a610be39648324b0134158f8625d9b