### PR TITLE
Validate entry IDs in reflection feedback

### DIFF
--- a/dashboard/student_views.py
+++ b/dashboard/student_views.py
@@ -452,6 +452,10 @@ def reflection_feedback(request):
     reflection = payload.get("reflection", {})
     entry_id = payload.get("entry_id")
     try:
+        entry_id = int(entry_id)
+    except (TypeError, ValueError):
+        return JsonResponse({"error": "Ungültige Eintrags-ID"}, status=400)
+    try:
         entry = student.entries.get(id=entry_id)
     except SRLEntry.DoesNotExist:
         return JsonResponse({"error": "Ungültiger Eintrag"}, status=404)


### PR DESCRIPTION
## Summary
- validate `entry_id` in `reflection_feedback` view and return appropriate errors for missing or unknown entries
- add tests covering invalid and missing entry IDs

## Testing
- `pytest dashboard/tests/test_views.py::test_reflection_feedback_missing_entry_id_returns_400 dashboard/tests/test_views.py::test_reflection_feedback_invalid_entry_returns_404 -q`

------
https://chatgpt.com/codex/tasks/task_e_68a627c397a883249fceeb19da1d8aa0