### PR TITLE
Gracefully handle missing student or entry in reflection feedback

### DIFF
--- a/dashboard/student_views.py
+++ b/dashboard/student_views.py
@@ -443,7 +443,14 @@ def reset_planning_feedback(request):
 @student_required
 @require_POST
 def reflection_feedback(request):
-    student = Student.objects.get(id=request.session["student_id"])
+    student_id = request.session.get("student_id")
+    if student_id is None:
+        return JsonResponse({"error": "Ungültiger Student"}, status=400)
+    try:
+        student = Student.objects.get(id=student_id)
+    except Student.DoesNotExist:
+        return JsonResponse({"error": "Ungültiger Student"}, status=404)
+
     try:
         payload = json.loads(request.body.decode("utf-8"))
     except json.JSONDecodeError:

--- a/dashboard/templates/dashboard/experimental_student_dashboard.html
+++ b/dashboard/templates/dashboard/experimental_student_dashboard.html
@@ -931,6 +931,7 @@ function setupReflectionModal(id) {
   function resetFeedback() {
     feedbackBox.textContent = '';
     feedbackBox.classList.add('hidden');
+    feedbackBox.classList.remove('text-red-600');
     saveBtn.disabled = true;
     feedbackBtn.textContent = 'Feedback erhalten';
     fetch("{% url 'reflection_feedback_reset' %}", {
@@ -953,7 +954,9 @@ function setupReflectionModal(id) {
       });
       if (!response.ok) {
         const err = await response.json().catch(() => ({}));
-        alert(err.error || 'Fehler beim Abrufen des Feedbacks.');
+        feedbackBox.textContent = err.error || 'Fehler beim Abrufen des Feedbacks.';
+        feedbackBox.classList.remove('hidden');
+        feedbackBox.classList.add('text-red-600');
         return;
       }
       const data = await response.json();
@@ -962,7 +965,9 @@ function setupReflectionModal(id) {
       saveBtn.disabled = false;
       feedbackBtn.textContent = 'Feedback aktualisieren';
     } catch (e) {
-      alert('Fehler beim Abrufen des Feedbacks.');
+      feedbackBox.textContent = 'Fehler beim Abrufen des Feedbacks.';
+      feedbackBox.classList.remove('hidden');
+      feedbackBox.classList.add('text-red-600');
     }
   });
 

--- a/dashboard/tests/test_views.py
+++ b/dashboard/tests/test_views.py
@@ -244,3 +244,25 @@ def test_reflection_feedback_invalid_entry_returns_404(client):
         content_type="application/json",
     )
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_reflection_feedback_invalid_student_returns_404(client):
+    teacher = User.objects.create_user(username="t1", password="pass")
+    classroom = Classroom.objects.create(
+        teacher=teacher,
+        name="Klasse A",
+        group_type="CONTROL",
+    )
+    # create a student but use a different id in session to simulate missing student
+    Student.objects.create(classroom=classroom, pseudonym="S1")
+    session = client.session
+    session["student_id"] = 999  # nonexistent student id
+    session.save()
+
+    response = client.post(
+        reverse("reflection_feedback"),
+        data=json.dumps({"reflection": {}, "entry_id": 1}),
+        content_type="application/json",
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Return JSON error when the student in session is missing or invalid
- Show backend feedback fetch errors inline instead of alerting
- Add regression test for missing student case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a635e0138083249d6ec3e069bf1829