### PR TITLE
Add AI feedback workflow to reflection modal

### DIFF
--- a/dashboard/student_urls.py
+++ b/dashboard/student_urls.py
@@ -30,6 +30,16 @@ urlpatterns = [
         name="student_entry_reflection_json",
     ),
     path(
+        "api/reflection/feedback/",
+        student_views.reflection_feedback,
+        name="reflection_feedback",
+    ),
+    path(
+        "api/reflection/feedback/reset/",
+        student_views.reset_reflection_feedback,
+        name="reflection_feedback_reset",
+    ),
+    path(
         "api/planning/feedback/",
         student_views.planning_feedback,
         name="planning_feedback",

--- a/dashboard/student_views.py
+++ b/dashboard/student_views.py
@@ -195,6 +195,7 @@ def add_reflection(request, entry_id):
         form = ReflectionForm(request.POST, instance=entry)
         if form.is_valid():
             form.save()
+            request.session.pop("reflection_ai_messages", None)
     return redirect("student_dashboard")
 
 
@@ -332,8 +333,108 @@ def add_reflection_json(request, entry_id):
     form = ReflectionForm(form_data, instance=entry)
     if form.is_valid():
         form.save()
+        request.session.pop("reflection_ai_messages", None)
         return JsonResponse({"status": "ok"})
     return JsonResponse({"errors": form.errors}, status=400)
+
+
+@student_required
+@require_POST
+def reflection_feedback(request):
+    student = Student.objects.get(id=request.session["student_id"])
+    try:
+        payload = json.loads(request.body.decode("utf-8"))
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    reflection = payload.get("reflection", {})
+    entries = student.entries.order_by("session_date")
+    diary = {
+        "Gesamtziel": student.overall_goal,
+        "Fälligkeitsdatum des Gesamtziels": student.overall_goal_due_date.isoformat()
+        if student.overall_goal_due_date
+        else None,
+        "Einträge": [_entry_nested(e) for e in entries],
+    }
+
+    base_prompt = (
+        "Rolle des KI-Assistenten:\n"
+        "Du bist ein Lerncoach, der einen Schüler während einer mehrwöchigen Projektarbeit unterstützt. "
+        "Der Schüler führt ein selbstreguliertes Lerntagebuch, in dem er seine Lernprozesse dokumentiert. "
+        "Jetzt bewertet der Schüler seine Reflexion zur abgeschlossenen Arbeitsphase. Deine Aufgabe ist es, "
+        "konstruktives, wissenschaftlich fundiertes Feedback zu dieser Reflexion zu geben, um den Schüler bei der "
+        "Entwicklung seiner Selbstregulationsfähigkeiten zu unterstützen.\n"
+        f"SRL Tagebuch: {json.dumps(diary, ensure_ascii=False)}\n"
+        f"Aktuelle Reflexion: {json.dumps(reflection, ensure_ascii=False)}\n"
+        "Aufgabe des KI-Assistenten\n"
+        "Analysiere alle vorliegenden Informationen:\n"
+        "Projektkontext (Gesamtziel + Frist)\n"
+        "Bisherige Tagebuch-Einträge und Planung (inkl. geplante Ziele, Strategien, Zeitmanagement)\n"
+        "Aktuelle Reflexion (Zielerreichung, Strategien, Lernen, Zeitmanagement, Motivation, Ausblick)\n"
+        "Beachte besonders: Widersprüche und Inkonsistenzen (z. B. „Zeitplan war realistisch“ vs. „große Abweichungen in der Umsetzung“).\n"
+        "Regeln für dein Feedback (wissenschaftlich gestützt)\n"
+        "Autonomie-Support (Selbstbestimmungstheorie)\n"
+        "Stelle offene, reflektierende Fragen, die den Schüler zum eigenen Nachdenken und Anpassen anregen.\n"
+        "Keine Anweisungen, sondern Impulse: „Wie erklärst du dir…?“, „Welche Alternativen siehst du…?“\n"
+        "Informativ, nicht wertend\n"
+        "Kein einfaches „gut/schlecht“.\n"
+        "Stattdessen sachliche Rückmeldungen mit konkreten Hinweisen: „Du hast deine Motivation als schwankend beschrieben – welche Strategien haben dir trotzdem geholfen, dranzubleiben?“\n"
+        "Ressourcen- und Stärkenorientierung\n"
+        "Anerkenne positive Entwicklungen („Du hast erkannt, dass dir Brainstorming geholfen hat – das zeigt, dass du deine Strategien gut reflektierst“).\n"
+        "Hebe Fortschritte hervor (z. B. verbesserte Planung im Vergleich zum Vorherigen).\n"
+        "Metakognition anregen\n"
+        "Stelle Fragen, die den Schüler dazu bringen, über eigene Denk- und Lernprozesse nachzudenken: „Was bedeutet es für dich, dass eine Strategie teilweise geholfen hat?“\n"
+        "Inkonsistenzen ansprechen\n"
+        "Identifiziere mögliche Widersprüche zwischen Planung, Umsetzung und Reflexion (z. B. „Du hast deine Planung als realistisch eingeschätzt, aber schreibst gleichzeitig, dass du stark vom Plan abgewichen bist – wie passt das für dich zusammen?“).\n"
+        "Stelle Nachfragen, ohne belehrend zu wirken.\n"
+        "Ausblick unterstützen\n"
+        "Hilf dem Schüler, aus seiner Reflexion konkrete nächste Schritte abzuleiten.\n"
+        "Stelle Fragen wie: „Welche deiner beschriebenen Strategien würdest du jetzt priorisieren?“ oder „Wie kannst du deine Motivation gezielt stärken?“\n"
+        "Erwartete Ausgabe\n"
+        "Formuliere dein Feedback als klar verständlichen Fließtext mit den folgenden Abschnitten:\n"
+        "Positives (Würdigung von Fortschritten und gelungenen Reflexionselementen)\n"
+        "Konkret-informative Hinweise (Ziele, Strategien, Zeitmanagement, Motivation, Konsistenz)\n"
+        "Reflektierende Fragen (die den Schüler zum Weiterdenken und Anpassen anregen)\n"
+        "Bestärkung (ermutigendes Fazit: kleine Anpassungen führen zu mehr Selbstregulation)"
+    )
+
+    messages = request.session.get("reflection_ai_messages")
+    if not messages:
+        messages = [{"role": "user", "content": base_prompt}]
+    else:
+        followup = (
+            "Der Schüler hat nun einen zweiten Entwurf eingereicht "
+            f"{json.dumps(reflection, ensure_ascii=False)} "
+            "gebe erneut Feedback nach den gleichen Richtlinien wie zuvor. Hebe dabei positive Veränderungen der Reflexion seit der letzten Version hervor."
+        )
+        messages.append({"role": "user", "content": followup})
+
+    settings = AppSettings.load()
+    if not settings.openai_api_key:
+        return JsonResponse({"error": "Kein OpenAI API Key hinterlegt."}, status=400)
+
+    try:
+        response = requests.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={"Authorization": f"Bearer {settings.openai_api_key}"},
+            json={"model": "gpt-4o-mini", "messages": messages},
+            timeout=30,
+        )
+        response.raise_for_status()
+        reply = response.json()["choices"][0]["message"]["content"]
+    except requests.RequestException:
+        return JsonResponse({"error": "Fehler bei der Verbindung zur OpenAI API."}, status=500)
+
+    messages.append({"role": "assistant", "content": reply})
+    request.session["reflection_ai_messages"] = messages
+    return JsonResponse({"feedback": reply})
+
+
+@student_required
+@require_POST
+def reset_reflection_feedback(request):
+    request.session.pop("reflection_ai_messages", None)
+    return JsonResponse({"status": "ok"})
 
 
 @student_required

--- a/dashboard/templates/dashboard/experimental_student_dashboard.html
+++ b/dashboard/templates/dashboard/experimental_student_dashboard.html
@@ -444,8 +444,12 @@
               </div>
             </div>
 
+            <div id="reflection-ai-feedback-{{ entry.id }}" class="hidden mb-4 p-2 border rounded bg-gray-50 text-sm"></div>
+
             <div class="flex justify-end space-x-2 mt-4">
-              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">Speichern</button>
+              <button type="button" id="get-reflection-feedback-{{ entry.id }}" class="bg-blue-500 text-white px-4 py-2 rounded">Feedback erhalten</button>
+              <button type="submit" id="reflection-save-{{ entry.id }}" class="bg-green-500 text-white px-4 py-2 rounded" disabled>Speichern</button>
+              <button type="button" data-modal-hide="reflectionModal-{{ entry.id }}" class="bg-red-500 text-white px-4 py-2 rounded">Abbrechen</button>
             </div>
           </form>
         </div>
@@ -767,145 +771,213 @@ function setupExecutionModal(id) {
 
 function setupReflectionModal(id) {
   const modal = document.getElementById('reflectionModal-' + id);
-  if (modal.dataset.initialized) return;
+  const form = document.getElementById('reflection-form-' + id);
+  const saveBtn = document.getElementById('reflection-save-' + id);
+  const feedbackBtn = document.getElementById('get-reflection-feedback-' + id);
+  const feedbackBox = document.getElementById('reflection-ai-feedback-' + id);
 
-  const goals = parseData('goals-data-' + id) || [];
-  const steps = parseData('steps-data-' + id) || [];
-  const strategies = parseData('strategies-data-' + id) || [];
-  const savedGA = parseData('goal-achievement-data-' + id) || [];
-  const savedSE = parseData('strategy-evaluation-data-' + id) || [];
+  if (!modal.dataset.initialized) {
+    const goals = parseData('goals-data-' + id) || [];
+    const steps = parseData('steps-data-' + id) || [];
+    const strategies = parseData('strategies-data-' + id) || [];
+    const savedGA = parseData('goal-achievement-data-' + id) || [];
+    const savedSE = parseData('strategy-evaluation-data-' + id) || [];
 
-  const gaInput = document.getElementById('goal-achievement-' + id);
-  const seInput = document.getElementById('strategy-evaluation-' + id);
-  const gaBody = document.querySelector('#goal-achievement-table-' + id + ' tbody');
-  const seBody = document.querySelector('#strategy-evaluation-table-' + id + ' tbody');
+    const gaInput = document.getElementById('goal-achievement-' + id);
+    const seInput = document.getElementById('strategy-evaluation-' + id);
+    const gaBody = document.querySelector('#goal-achievement-table-' + id + ' tbody');
+    const seBody = document.querySelector('#strategy-evaluation-table-' + id + ' tbody');
 
-  const unplanned = steps.filter(g => !goals.includes(g));
-  const allGoals = goals.concat(unplanned);
+    const learnedSubjectField = document.getElementById('learned-subject-' + id);
+    const learnedWorkField = document.getElementById('learned-work-' + id);
+    const planningRealisticField = document.getElementById('planning-realistic-' + id);
+    const planningDeviationsField = document.getElementById('planning-deviations-' + id);
+    const motivationRatingField = document.getElementById('motivation-rating-' + id);
+    const motivationImproveField = document.getElementById('motivation-improve-' + id);
+    const nextPhaseField = document.getElementById('next-phase-' + id);
+    const strategyOutlookField = document.getElementById('strategy-outlook-' + id);
 
-  const gaData = allGoals.map(g => {
-    const found = savedGA.find(item => item.goal === g) || {};
-    return {
-      goal: g,
-      unplanned: unplanned.includes(g),
-      achievement: found.achievement || '',
-      comment: found.comment || ''
-    };
-  });
+    const unplanned = steps.filter(g => !goals.includes(g));
+    const allGoals = goals.concat(unplanned);
 
-  const seData = strategies.map(s => {
-    const found = savedSE.find(item => item.strategy === s) || {};
-    return {
-      strategy: s,
-      helpful: found.helpful || '',
-      reason: found.reason || '',
-      reuse: found.reuse || ''
-    };
-  });
-
-  function updateHidden() {
-    gaInput.value = JSON.stringify(gaData);
-    seInput.value = JSON.stringify(seData);
-  }
-
-  function renderGoals() {
-    gaBody.innerHTML = '';
-    gaData.forEach((item, i) => {
-      const tr = document.createElement('tr');
-      const tdG = document.createElement('td');
-      tdG.className = 'border px-2 py-1';
-      tdG.textContent = item.goal + (item.unplanned ? ' (ungeplant)' : '');
-      const tdA = document.createElement('td');
-      tdA.className = 'border px-2 py-1 text-center';
-      ['vollständig','teilweise','nicht'].forEach(val => {
-        const label = document.createElement('label');
-        label.className = 'mr-2';
-        const radio = document.createElement('input');
-        radio.type = 'radio';
-        radio.name = 'ga-' + id + '-' + i;
-        radio.value = val;
-        radio.required = true;
-        if (item.achievement === val) radio.checked = true;
-        radio.addEventListener('change', () => { item.achievement = val; updateHidden(); });
-        label.appendChild(radio);
-        label.appendChild(document.createTextNode(val));
-        tdA.appendChild(label);
-      });
-      const tdC = document.createElement('td');
-      tdC.className = 'border px-2 py-1';
-      const ta = document.createElement('textarea');
-      ta.className = 'w-full border rounded p-1';
-      ta.rows = 1;
-      ta.required = true;
-      ta.value = item.comment;
-      ta.addEventListener('input', e => { item.comment = e.target.value; updateHidden(); });
-      tdC.appendChild(ta);
-      tr.appendChild(tdG);
-      tr.appendChild(tdA);
-      tr.appendChild(tdC);
-      gaBody.appendChild(tr);
+    const gaData = allGoals.map(g => {
+      const found = savedGA.find(item => item.goal === g) || {};
+      return {
+        goal: g,
+        unplanned: unplanned.includes(g),
+        achievement: found.achievement || '',
+        comment: found.comment || ''
+      };
     });
-  }
 
-  function renderStrategies() {
-    seBody.innerHTML = '';
-    seData.forEach((item, i) => {
-      const tr = document.createElement('tr');
-      const tdS = document.createElement('td');
-      tdS.className = 'border px-2 py-1';
-      tdS.textContent = item.strategy;
-      const tdH = document.createElement('td');
-      tdH.className = 'border px-2 py-1 text-center';
-      ['ja','teilweise','nein'].forEach(val => {
-        const label = document.createElement('label');
-        label.className = 'mr-2';
-        const radio = document.createElement('input');
-        radio.type = 'radio';
-        radio.name = 'se-help-' + id + '-' + i;
-        radio.value = val;
-        radio.required = true;
-        if (item.helpful === val) radio.checked = true;
-        radio.addEventListener('change', () => { item.helpful = val; updateHidden(); });
-        label.appendChild(radio);
-        label.appendChild(document.createTextNode(val));
-        tdH.appendChild(label);
-      });
-      const tdR = document.createElement('td');
-      tdR.className = 'border px-2 py-1';
-      const inp = document.createElement('input');
-      inp.type = 'text';
-      inp.className = 'w-full border rounded p-1';
-      inp.value = item.reason;
-      inp.addEventListener('input', e => { item.reason = e.target.value; updateHidden(); });
-      tdR.appendChild(inp);
-      const tdU = document.createElement('td');
-      tdU.className = 'border px-2 py-1 text-center';
-      ['ja','nein','vielleicht'].forEach(val => {
-        const label = document.createElement('label');
-        label.className = 'mr-2';
-        const radio = document.createElement('input');
-        radio.type = 'radio';
-        radio.name = 'se-reuse-' + id + '-' + i;
-        radio.value = val;
-        radio.required = true;
-        if (item.reuse === val) radio.checked = true;
-        radio.addEventListener('change', () => { item.reuse = val; updateHidden(); });
-        label.appendChild(radio);
-        label.appendChild(document.createTextNode(val));
-        tdU.appendChild(label);
-      });
-      tr.appendChild(tdS);
-      tr.appendChild(tdH);
-      tr.appendChild(tdR);
-      tr.appendChild(tdU);
-      seBody.appendChild(tr);
+    const seData = strategies.map(s => {
+      const found = savedSE.find(item => item.strategy === s) || {};
+      return {
+        strategy: s,
+        helpful: found.helpful || '',
+        reason: found.reason || '',
+        reuse: found.reuse || ''
+      };
     });
+
+    function updateHidden() {
+      gaInput.value = JSON.stringify(gaData);
+      seInput.value = JSON.stringify(seData);
+    }
+
+    function renderGoals() {
+      gaBody.innerHTML = '';
+      gaData.forEach((item, i) => {
+        const tr = document.createElement('tr');
+        const tdG = document.createElement('td');
+        tdG.className = 'border px-2 py-1';
+        tdG.textContent = item.goal + (item.unplanned ? ' (ungeplant)' : '');
+        const tdA = document.createElement('td');
+        tdA.className = 'border px-2 py-1 text-center';
+        ['vollständig','teilweise','nicht'].forEach(val => {
+          const label = document.createElement('label');
+          label.className = 'mr-2';
+          const radio = document.createElement('input');
+          radio.type = 'radio';
+          radio.name = 'ga-' + id + '-' + i;
+          radio.value = val;
+          radio.required = true;
+          if (item.achievement === val) radio.checked = true;
+          radio.addEventListener('change', () => { item.achievement = val; updateHidden(); });
+          label.appendChild(radio);
+          label.appendChild(document.createTextNode(val));
+          tdA.appendChild(label);
+        });
+        const tdC = document.createElement('td');
+        tdC.className = 'border px-2 py-1';
+        const ta = document.createElement('textarea');
+        ta.className = 'w-full border rounded p-1';
+        ta.rows = 1;
+        ta.required = true;
+        ta.value = item.comment;
+        ta.addEventListener('input', e => { item.comment = e.target.value; updateHidden(); });
+        tdC.appendChild(ta);
+        tr.appendChild(tdG);
+        tr.appendChild(tdA);
+        tr.appendChild(tdC);
+        gaBody.appendChild(tr);
+      });
+    }
+
+    function renderStrategies() {
+      seBody.innerHTML = '';
+      seData.forEach((item, i) => {
+        const tr = document.createElement('tr');
+        const tdS = document.createElement('td');
+        tdS.className = 'border px-2 py-1';
+        tdS.textContent = item.strategy;
+        const tdH = document.createElement('td');
+        tdH.className = 'border px-2 py-1 text-center';
+        ['ja','teilweise','nein'].forEach(val => {
+          const label = document.createElement('label');
+          label.className = 'mr-2';
+          const radio = document.createElement('input');
+          radio.type = 'radio';
+          radio.name = 'se-help-' + id + '-' + i;
+          radio.value = val;
+          radio.required = true;
+          if (item.helpful === val) radio.checked = true;
+          radio.addEventListener('change', () => { item.helpful = val; updateHidden(); });
+          label.appendChild(radio);
+          label.appendChild(document.createTextNode(val));
+          tdH.appendChild(label);
+        });
+        const tdR = document.createElement('td');
+        tdR.className = 'border px-2 py-1';
+        const inp = document.createElement('input');
+        inp.type = 'text';
+        inp.className = 'w-full border rounded p-1';
+        inp.value = item.reason;
+        inp.addEventListener('input', e => { item.reason = e.target.value; updateHidden(); });
+        tdR.appendChild(inp);
+        const tdU = document.createElement('td');
+        tdU.className = 'border px-2 py-1 text-center';
+        ['ja','nein','vielleicht'].forEach(val => {
+          const label = document.createElement('label');
+          label.className = 'mr-2';
+          const radio = document.createElement('input');
+          radio.type = 'radio';
+          radio.name = 'se-reuse-' + id + '-' + i;
+          radio.value = val;
+          radio.required = true;
+          if (item.reuse === val) radio.checked = true;
+          radio.addEventListener('change', () => { item.reuse = val; updateHidden(); });
+          label.appendChild(radio);
+          label.appendChild(document.createTextNode(val));
+          tdU.appendChild(label);
+        });
+        tr.appendChild(tdS);
+        tr.appendChild(tdH);
+        tr.appendChild(tdR);
+        tr.appendChild(tdU);
+        seBody.appendChild(tr);
+      });
+    }
+
+    function getReflectionData() {
+      return {
+        goal_achievement: gaData,
+        strategy_evaluation: seData,
+        learned_subject: learnedSubjectField.value,
+        learned_work: learnedWorkField.value,
+        planning_realistic: planningRealisticField.value,
+        planning_deviations: planningDeviationsField.value,
+        motivation_rating: motivationRatingField.value,
+        motivation_improve: motivationImproveField.value,
+        next_phase: nextPhaseField.value,
+        strategy_outlook: strategyOutlookField.value
+      };
+    }
+
+    feedbackBtn.addEventListener('click', async () => {
+      updateHidden();
+      try {
+        const response = await fetch("{% url 'reflection_feedback' %}", {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': getCookie('csrftoken'),
+          },
+          body: JSON.stringify({ reflection: getReflectionData() })
+        });
+        if (!response.ok) {
+          const err = await response.json().catch(() => ({}));
+          alert(err.error || 'Fehler beim Abrufen des Feedbacks.');
+          return;
+        }
+        const data = await response.json();
+        feedbackBox.textContent = data.feedback;
+        feedbackBox.classList.remove('hidden');
+        saveBtn.disabled = false;
+        feedbackBtn.textContent = 'Feedback aktualisieren';
+      } catch (e) {
+        alert('Fehler beim Abrufen des Feedbacks.');
+      }
+    });
+
+    modal.resetFeedback = function() {
+      feedbackBox.textContent = '';
+      feedbackBox.classList.add('hidden');
+      saveBtn.disabled = true;
+      feedbackBtn.textContent = 'Feedback erhalten';
+      fetch("{% url 'reflection_feedback_reset' %}", {
+        method: 'POST',
+        headers: { 'X-CSRFToken': getCookie('csrftoken') }
+      });
+    };
+
+    renderGoals();
+    renderStrategies();
+    updateHidden();
+    modal.dataset.initialized = '1';
   }
 
-  renderGoals();
-  renderStrategies();
-  updateHidden();
-  modal.dataset.initialized = '1';
+  if (modal.resetFeedback) modal.resetFeedback();
 }
 
 function finalizeExecution(id) {


### PR DESCRIPTION
## Summary
- enable AI-generated feedback for reflection modal similar to planning modal
- expose reflection feedback endpoints and reset logic
- disable reflection save until feedback retrieved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6410a7b6c8324b97940e99c9655c1