### PR TITLE
Add AI-assisted reflection feedback modal

### DIFF
--- a/dashboard/student_urls.py
+++ b/dashboard/student_urls.py
@@ -39,4 +39,14 @@ urlpatterns = [
         student_views.reset_planning_feedback,
         name="planning_feedback_reset",
     ),
+    path(
+        "api/reflection/feedback/",
+        student_views.reflection_feedback,
+        name="reflection_feedback",
+    ),
+    path(
+        "api/reflection/feedback/reset/",
+        student_views.reset_reflection_feedback,
+        name="reflection_feedback_reset",
+    ),
 ]

--- a/dashboard/student_views.py
+++ b/dashboard/student_views.py
@@ -436,3 +436,103 @@ def planning_feedback(request):
 def reset_planning_feedback(request):
     request.session.pop("planning_ai_messages", None)
     return JsonResponse({"status": "ok"})
+
+
+@student_required
+@require_POST
+def reflection_feedback(request):
+    student = Student.objects.get(id=request.session["student_id"])
+    try:
+        payload = json.loads(request.body.decode("utf-8"))
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    reflection = payload.get("reflection", {})
+    entries = student.entries.order_by("session_date")
+    diary = {
+        "Gesamtziel": student.overall_goal,
+        "Fälligkeitsdatum des Gesamtziels": student.overall_goal_due_date.isoformat()
+        if student.overall_goal_due_date
+        else None,
+        "Einträge": [_entry_nested(e) for e in entries],
+    }
+
+    base_prompt = (
+        "Rolle des KI-Assistenten:\n"
+        "Du bist ein Lerncoach, der einen Schüler während einer mehrwöchigen Projektarbeit unterstützt. "
+        "Der Schüler führt ein selbstreguliertes Lerntagebuch, in dem er seine Lernprozesse dokumentiert. "
+        "Jetzt bewertet der Schüler seine Reflexion zur abgeschlossenen Arbeitsphase. "
+        "Deine Aufgabe ist es, konstruktives, wissenschaftlich fundiertes Feedback zu dieser Reflexion zu geben, "
+        "um den Schüler bei der Entwicklung seiner Selbstregulationsfähigkeiten zu unterstützen.\n"
+        "Eingabedaten:\n"
+        f"-> Das derzeitige SRL Tagebuch: {json.dumps(diary, ensure_ascii=False)}\n"
+        f"-> Die aktuelle Reflexion des Schülers {json.dumps(reflection, ensure_ascii=False)}\n"
+        "Aufgabe des KI-Assistenten\n"
+        "Analysiere alle vorliegenden Informationen:\n"
+        "Projektkontext (Gesamtziel + Frist)\n"
+        "Bisherige Tagebuch-Einträge und Planung (inkl. geplante Ziele, Strategien, Zeitmanagement)\n"
+        "Aktuelle Reflexion (Zielerreichung, Strategien, Lernen, Zeitmanagement, Motivation, Ausblick)\n"
+        "Beachte besonders: Widersprüche und Inkonsistenzen (z. B. „Zeitplan war realistisch“ vs. „große Abweichungen in der Umsetzung“).\n"
+        "Regeln für dein Feedback (wissenschaftlich gestützt)\n"
+        "Autonomie-Support (Selbstbestimmungstheorie)\n"
+        "Stelle offene, reflektierende Fragen, die den Schüler zum eigenen Nachdenken und Anpassen anregen.\n"
+        "Keine Anweisungen, sondern Impulse: „Wie erklärst du dir…?“, „Welche Alternativen siehst du…?“\n"
+        "Informativ, nicht wertend\n"
+        "Kein einfaches „gut/schlecht“.\n"
+        "Stattdessen sachliche Rückmeldungen mit konkreten Hinweisen: „Du hast deine Motivation als schwankend beschrieben – welche Strategien haben dir trotzdem geholfen, dranzubleiben?“\n"
+        "Ressourcen- und Stärkenorientierung\n"
+        "Anerkenne positive Entwicklungen („Du hast erkannt, dass dir Brainstorming geholfen hat – das zeigt, dass du deine Strategien gut reflektierst“).\n"
+        "Hebe Fortschritte hervor (z. B. verbesserte Planung im Vergleich zum Vorherigen).\n"
+        "Metakognition anregen\n"
+        "Stelle Fragen, die den Schüler dazu bringen, über eigene Denk- und Lernprozesse nachzudenken: „Was bedeutet es für dich, dass eine Strategie teilweise geholfen hat?“\n"
+        "Inkonsistenzen ansprechen\n"
+        "Identifiziere mögliche Widersprüche zwischen Planung, Umsetzung und Reflexion (z. B. „Du hast deine Planung als realistisch eingeschätzt, aber schreibst gleichzeitig, dass du stark vom Plan abgewichen bist – wie passt das für dich zusammen?“).\n"
+        "Stelle Nachfragen, ohne belehrend zu wirken.\n"
+        "Ausblick unterstützen\n"
+        "Hilf dem Schüler, aus seiner Reflexion konkrete nächste Schritte abzuleiten.\n"
+        "Stelle Fragen wie: „Welche deiner beschriebenen Strategien würdest du jetzt priorisieren?“ oder „Wie kannst du deine Motivation gezielt stärken?“\n"
+        "Erwartete Ausgabe\n"
+        "Formuliere dein Feedback als klar verständlichen Fließtext mit den folgenden Abschnitten:\n"
+        "Positives (Würdigung von Fortschritten und gelungenen Reflexionselementen)\n"
+        "Konkret-informative Hinweise (Ziele, Strategien, Zeitmanagement, Motivation, Konsistenz)\n"
+        "Reflektierende Fragen (die den Schüler zum Weiterdenken und Anpassen anregen)\n"
+        "Bestärkung (ermutigendes Fazit: kleine Anpassungen führen zu mehr Selbstregulation)"
+    )
+
+    messages = request.session.get("reflection_ai_messages")
+    if not messages:
+        messages = [{"role": "user", "content": base_prompt}]
+    else:
+        followup = (
+            "Der Schüler hat nun einen zweiten Entwurf eingereicht "
+            f"{json.dumps(reflection, ensure_ascii=False)} "
+            "gebe erneut Feedback nach den gleichen Richtlinien wie zuvor. Hebe dabei positive Veränderungen der Reflexion seit der letzten Version hervor."
+        )
+        messages.append({"role": "user", "content": followup})
+
+    settings = AppSettings.load()
+    if not settings.openai_api_key:
+        return JsonResponse({"error": "Kein OpenAI API Key hinterlegt."}, status=400)
+
+    try:
+        response = requests.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={"Authorization": f"Bearer {settings.openai_api_key}"},
+            json={"model": "gpt-4o-mini", "messages": messages},
+            timeout=30,
+        )
+        response.raise_for_status()
+        reply = response.json()["choices"][0]["message"]["content"]
+    except requests.RequestException:
+        return JsonResponse({"error": "Fehler bei der Verbindung zur OpenAI API."}, status=500)
+
+    messages.append({"role": "assistant", "content": reply})
+    request.session["reflection_ai_messages"] = messages
+    return JsonResponse({"feedback": reply})
+
+
+@student_required
+@require_POST
+def reset_reflection_feedback(request):
+    request.session.pop("reflection_ai_messages", None)
+    return JsonResponse({"status": "ok"})

--- a/dashboard/templates/dashboard/experimental_student_dashboard.html
+++ b/dashboard/templates/dashboard/experimental_student_dashboard.html
@@ -444,8 +444,11 @@
               </div>
             </div>
 
+            <div id="ai-feedback-reflection-{{ entry.id }}" class="hidden mb-4 p-2 border rounded bg-gray-50 text-sm"></div>
+
             <div class="flex justify-end space-x-2 mt-4">
-              <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">Speichern</button>
+              <button type="button" id="get-reflection-feedback-{{ entry.id }}" class="bg-blue-500 text-white px-4 py-2 rounded">Feedback erhalten</button>
+              <button type="submit" id="reflection-save-{{ entry.id }}" class="bg-green-500 text-white px-4 py-2 rounded" disabled>Speichern</button>
             </div>
           </form>
         </div>
@@ -767,6 +770,22 @@ function setupExecutionModal(id) {
 
 function setupReflectionModal(id) {
   const modal = document.getElementById('reflectionModal-' + id);
+  const saveBtn = document.getElementById('reflection-save-' + id);
+  const feedbackBtn = document.getElementById('get-reflection-feedback-' + id);
+  const feedbackBox = document.getElementById('ai-feedback-reflection-' + id);
+
+  function resetFeedback() {
+    feedbackBox.textContent = '';
+    feedbackBox.classList.add('hidden');
+    saveBtn.disabled = true;
+    feedbackBtn.textContent = 'Feedback erhalten';
+    fetch("{% url 'reflection_feedback_reset' %}", {
+      method: 'POST',
+      headers: { 'X-CSRFToken': getCookie('csrftoken') }
+    });
+  }
+
+  resetFeedback();
   if (modal.dataset.initialized) return;
 
   const goals = parseData('goals-data-' + id) || [];
@@ -806,6 +825,21 @@ function setupReflectionModal(id) {
   function updateHidden() {
     gaInput.value = JSON.stringify(gaData);
     seInput.value = JSON.stringify(seData);
+  }
+
+  function getReflectionData() {
+    return {
+      goal_achievement: gaData,
+      strategy_evaluation: seData,
+      learned_subject: document.getElementById('learned-subject-' + id)?.value || '',
+      learned_work: document.getElementById('learned-work-' + id)?.value || '',
+      planning_realistic: document.getElementById('planning-realistic-' + id)?.value || '',
+      planning_deviations: document.getElementById('planning-deviations-' + id)?.value || '',
+      motivation_rating: document.getElementById('motivation-rating-' + id)?.value || '',
+      motivation_improve: document.getElementById('motivation-improve-' + id)?.value || '',
+      next_phase: document.getElementById('next-phase-' + id)?.value || '',
+      strategy_outlook: document.getElementById('strategy-outlook-' + id)?.value || ''
+    };
   }
 
   function renderGoals() {
@@ -901,6 +935,32 @@ function setupReflectionModal(id) {
       seBody.appendChild(tr);
     });
   }
+
+  feedbackBtn.addEventListener('click', async () => {
+    updateHidden();
+    try {
+      const response = await fetch("{% url 'reflection_feedback' %}", {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCookie('csrftoken'),
+        },
+        body: JSON.stringify({ reflection: getReflectionData() })
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        alert(err.error || 'Fehler beim Abrufen des Feedbacks.');
+        return;
+      }
+      const data = await response.json();
+      feedbackBox.textContent = data.feedback;
+      feedbackBox.classList.remove('hidden');
+      saveBtn.disabled = false;
+      feedbackBtn.textContent = 'Feedback aktualisieren';
+    } catch (e) {
+      alert('Fehler beim Abrufen des Feedbacks.');
+    }
+  });
 
   renderGoals();
   renderStrategies();


### PR DESCRIPTION
## Summary
- extend student API and views to provide OpenAI-powered reflection feedback
- hook up reflection modal with feedback and save gating, mirroring planning flow
- reset feedback sessions and add update button for subsequent drafts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6410a7b6c8324b97940e99c9655c1