### PR TITLE
Redirect root URL to student dashboard

### DIFF
--- a/EduNav/urls.py
+++ b/EduNav/urls.py
@@ -15,10 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import RedirectView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("dashboard/", include("dashboard.urls")),
     path("student/", include("dashboard.student_urls")),
+    path("", RedirectView.as_view(url="/student/dashboard/", permanent=False)),
     path("", include("django.contrib.auth.urls")),
 ]


### PR DESCRIPTION
## Summary
- Redirect `/` to `/student/dashboard/` for a streamlined student experience
- Import `RedirectView` and add redirect route in `EduNav/urls.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a647888e388324aa4ebf2102b5de24