### PR TITLE
Render AI feedback as sanitized markdown

### DIFF
--- a/dashboard/templates/dashboard/experimental_student_dashboard.html
+++ b/dashboard/templates/dashboard/experimental_student_dashboard.html
@@ -51,6 +51,13 @@
   .timeline-button::before {
     display: none;
   }
+  .markdown-body h1, .markdown-body h2, .markdown-body h3 { margin-top: .75rem; font-weight: 700; }
+  .markdown-body p, .markdown-body ul, .markdown-body ol { margin: .5rem 0; }
+  .markdown-body code { background:#f3f4f6; padding:.15rem .3rem; border-radius:.25rem; }
+  .markdown-body pre { background:#f3f4f6; padding:.75rem; border-radius:.5rem; overflow:auto; }
+  .markdown-body ul { list-style: disc; padding-left: 1.25rem; }
+  .markdown-body ol { list-style: decimal; padding-left: 1.25rem; }
+  .markdown-body blockquote { border-left: 4px solid #e5e7eb; padding-left:.75rem; color:#374151; }
 </style>
 {% if messages %}
 <div class="mb-4">
@@ -444,7 +451,7 @@
               </div>
             </div>
 
-            <div id="ai-feedback-reflection-{{ entry.id }}" class="hidden mb-4 p-2 border rounded bg-gray-50 text-sm"></div>
+            <div id="ai-feedback-reflection-{{ entry.id }}" class="markdown-body hidden mb-4 p-2 border rounded bg-gray-50 text-sm"></div>
 
             <div class="flex justify-end space-x-2 mt-4">
               <button type="button" id="get-reflection-feedback-{{ entry.id }}" class="bg-blue-500 text-white px-4 py-2 rounded">Feedback erhalten</button>
@@ -512,7 +519,7 @@
             </table>
           </div>
 
-          <div id="ai-feedback" class="hidden mb-4 p-2 border rounded bg-gray-50 text-sm"></div>
+          <div id="ai-feedback" class="markdown-body hidden mb-4 p-2 border rounded bg-gray-50 text-sm"></div>
 
           <div class="flex justify-end space-x-2 mt-4">
             <button type="button" id="get-feedback" class="bg-blue-500 text-white px-4 py-2 rounded">Feedback erhalten</button>
@@ -558,10 +565,13 @@
   </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/ScrollTrigger.min.js"></script>
 <script>
+marked.setOptions({ breaks: true, gfm: true });
 const MAX_MINUTES = {{ student.classroom.max_planning_execution_minutes }};
 function parseData(elId) {
   const el = document.getElementById(elId);
@@ -953,7 +963,7 @@ function setupReflectionModal(id) {
         return;
       }
       const data = await response.json();
-      feedbackBox.textContent = data.feedback;
+      feedbackBox.innerHTML = DOMPurify.sanitize(marked.parse(data.feedback));
       feedbackBox.classList.remove('hidden');
       saveBtn.disabled = false;
       feedbackBtn.textContent = 'Feedback aktualisieren';
@@ -1319,7 +1329,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
       }
       const data = await response.json();
-      feedbackBox.textContent = data.feedback;
+      feedbackBox.innerHTML = DOMPurify.sanitize(marked.parse(data.feedback));
       feedbackBox.classList.remove('hidden');
       saveBtn.disabled = false;
       feedbackBtn.textContent = 'Feedback aktualisieren';


### PR DESCRIPTION
## Summary
- Render planning and reflection AI feedback as sanitized Markdown
- Add marked + DOMPurify, global config, and styling for markdown content

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1c149ab448324a464844011020c17